### PR TITLE
refactor: remove repeated `Service` interface from server pkg

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,19 +132,18 @@ func main() {
 							}
 							sc.PrivateKey = privKey
 
-							indexingService, err := construct.Construct(sc)
+							indexer, err := construct.Construct(sc)
 							if err != nil {
 								return err
 							}
-							err = indexingService.Startup(cCtx.Context)
+							err = indexer.Startup(cCtx.Context)
 							if err != nil {
 								return err
 							}
 							defer func() {
-								indexingService.Shutdown(cCtx.Context)
+								indexer.Shutdown(cCtx.Context)
 							}()
-							opts = append(opts, server.WithService(indexingService))
-							return server.ListenAndServe(addr, opts...)
+							return server.ListenAndServe(addr, indexer, opts...)
 						},
 					},
 				},

--- a/pkg/construct/construct.go
+++ b/pkg/construct/construct.go
@@ -12,7 +12,6 @@ import (
 	ipnifind "github.com/ipni/go-libipni/find/client"
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
 	goredis "github.com/redis/go-redis/v9"
-	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/indexing-service/pkg/internal/jobqueue"
 	"github.com/storacha/indexing-service/pkg/redis"
 	"github.com/storacha/indexing-service/pkg/service"
@@ -23,7 +22,7 @@ import (
 	"github.com/storacha/indexing-service/pkg/service/providerindex/notifier"
 	"github.com/storacha/indexing-service/pkg/service/providerindex/publisher"
 	"github.com/storacha/indexing-service/pkg/service/providerindex/server"
-	"github.com/storacha/indexing-service/pkg/service/queryresult"
+	"github.com/storacha/indexing-service/pkg/types"
 )
 
 var log = logging.Logger("service")
@@ -105,12 +104,11 @@ func WithDatastore(ds datastore.Batching) Option {
 }
 
 // Service is the core methods of the indexing service but with additional
+// lifecycle methods.
 type Service interface {
+	types.Service
 	Startup(ctx context.Context) error
 	Shutdown(ctx context.Context) error
-	CacheClaim(ctx context.Context, claim delegation.Delegation) error
-	PublishClaim(ctx context.Context, claim delegation.Delegation) error
-	Query(ctx context.Context, q service.Query) (queryresult.QueryResult, error)
 }
 
 type serviceWithLifeCycle struct {

--- a/pkg/service/contentclaims/server.go
+++ b/pkg/service/contentclaims/server.go
@@ -3,10 +3,11 @@ package contentclaims
 import (
 	"github.com/storacha/go-ucanto/principal"
 	"github.com/storacha/go-ucanto/server"
+	"github.com/storacha/indexing-service/pkg/types"
 )
 
-func NewServer(id principal.Signer) (server.ServerView, error) {
-	service := NewService()
+func NewServer(id principal.Signer, indexer types.Service) (server.ServerView, error) {
+	service := NewService(indexer)
 	var opts []server.Option
 	for ability, method := range service {
 		opts = append(opts, server.WithServiceMethod(ability, method))

--- a/pkg/service/contentclaims/server_test.go
+++ b/pkg/service/contentclaims/server_test.go
@@ -25,7 +25,7 @@ var rcptsch = []byte(`
 `)
 
 func TestServer(t *testing.T) {
-	server, err := NewServer(testutil.Service)
+	server, err := NewServer(testutil.Service, nil)
 	require.NoError(t, err)
 
 	conn, err := client.NewConnection(testutil.Service, server)

--- a/pkg/service/contentclaims/service.go
+++ b/pkg/service/contentclaims/service.go
@@ -7,11 +7,12 @@ import (
 	"github.com/storacha/go-ucanto/server"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/indexing-service/pkg/capability/assert"
+	"github.com/storacha/indexing-service/pkg/types"
 )
 
 var log = logging.Logger("contentclaims")
 
-func NewService() map[ucan.Ability]server.ServiceMethod[assert.Unit] {
+func NewService(indexer types.Service) map[ucan.Ability]server.ServiceMethod[assert.Unit] {
 	return map[ucan.Ability]server.ServiceMethod[assert.Unit]{
 		assert.Equals.Can(): server.Provide(
 			assert.Equals,

--- a/pkg/service/queryresult/queryresult.go
+++ b/pkg/service/queryresult/queryresult.go
@@ -20,23 +20,13 @@ import (
 	"github.com/storacha/indexing-service/pkg/types"
 )
 
-// QueryResult is an encodable result of a query
-type QueryResult interface {
-	ipld.View
-	// Claims is a list of links to the root bock of claims that can be found in this message
-	Claims() []ipld.Link
-	// Indexes is a list of links to the CID hash of archived sharded dag indexes that can be found in this
-	// message
-	Indexes() []ipld.Link
-}
-
 type queryResult struct {
 	root ipld.Block
 	data *qdm.QueryResultModel0_1
 	blks blockstore.BlockReader
 }
 
-var _ QueryResult = (*queryResult)(nil)
+var _ types.QueryResult = (*queryResult)(nil)
 
 func (q *queryResult) Blocks() iter.Seq2[block.Block, error] {
 	return q.blks.Iterator()
@@ -62,7 +52,7 @@ func (q *queryResult) Root() block.Block {
 }
 
 // Build generates a new encodable QueryResult
-func Build(claims map[cid.Cid]delegation.Delegation, indexes bytemap.ByteMap[types.EncodedContextID, blobindex.ShardedDagIndexView]) (QueryResult, error) {
+func Build(claims map[cid.Cid]delegation.Delegation, indexes bytemap.ByteMap[types.EncodedContextID, blobindex.ShardedDagIndexView]) (types.QueryResult, error) {
 	bs, err := blockstore.NewBlockStore()
 	if err != nil {
 		return nil, err

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-ucanto/core/delegation"
-	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/indexing-service/pkg/blobindex"
 	"github.com/storacha/indexing-service/pkg/internal/bytemap"
 	"github.com/storacha/indexing-service/pkg/internal/jobwalker"
@@ -25,17 +24,6 @@ import (
 	"github.com/storacha/indexing-service/pkg/service/queryresult"
 	"github.com/storacha/indexing-service/pkg/types"
 )
-
-// Match narrows parameters for locating providers/claims for a set of multihashes
-type Match struct {
-	Subject []did.DID
-}
-
-// Query is a query for several multihashes
-type Query struct {
-	Hashes []multihash.Multihash
-	Match  Match
-}
 
 // ProviderIndex is a read/write interface to a local cache of providers that falls back to IPNI
 type ProviderIndex interface {
@@ -116,7 +104,7 @@ type queryResult struct {
 }
 
 type queryState struct {
-	q      *Query
+	q      *types.Query
 	qr     *queryResult
 	visits map[jobKey]struct{}
 }
@@ -253,7 +241,7 @@ func (is *IndexingService) jobHandler(mhCtx context.Context, j job, spawn func(j
 // 5. Query IPNIIndex for any location claims for any shards that contain the multihash based on the ShardedDagIndex
 // 6. Read the requisite claims from the ClaimLookup
 // 7. Return all discovered claims and sharded dag indexes
-func (is *IndexingService) Query(ctx context.Context, q Query) (queryresult.QueryResult, error) {
+func (is *IndexingService) Query(ctx context.Context, q types.Query) (types.QueryResult, error) {
 	initialJobs := make([]job, 0, len(q.Hashes))
 	for _, mh := range q.Hashes {
 		initialJobs = append(initialJobs, job{mh, nil, nil, standardJobType})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipni/go-libipni/find/model"
 	mh "github.com/multiformats/go-multihash"
 	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/indexing-service/pkg/blobindex"
 )
@@ -50,3 +51,31 @@ type ContentClaimsStore Cache[cid.Cid, delegation.Delegation]
 
 // ShardedDagIndexStore caches fetched sharded dag indexes
 type ShardedDagIndexStore Cache[EncodedContextID, blobindex.ShardedDagIndexView]
+
+// Match narrows parameters for locating providers/claims for a set of multihashes
+type Match struct {
+	Subject []did.DID
+}
+
+// Query is a query for several multihashes
+type Query struct {
+	Hashes []mh.Multihash
+	Match  Match
+}
+
+// QueryResult is an encodable result of a query
+type QueryResult interface {
+	ipld.View
+	// Claims is a list of links to the root bock of claims that can be found in this message
+	Claims() []ipld.Link
+	// Indexes is a list of links to the CID hash of archived sharded dag indexes that can be found in this
+	// message
+	Indexes() []ipld.Link
+}
+
+// Service is the core methods of the indexing service.
+type Service interface {
+	CacheClaim(ctx context.Context, claim delegation.Delegation) error
+	PublishClaim(ctx context.Context, claim delegation.Delegation) error
+	Query(ctx context.Context, q Query) (QueryResult, error)
+}


### PR DESCRIPTION
Removes repeated `Service` interface from `pkg/server/server.go` and adds to `pkg/types/types.go`. The `Service` defined in `pkg/construct/construct.go` (with lifecycle methods) now extends `types.Service`. Had to move some query structs into `types` to resolve import cycles.

This also now allows the indexing service to be passed as a dependency to the content claims service, and is done here also (although currently unused).