### PR TITLE
feat: cache claims in ClaimLookup

### DIFF
--- a/pkg/construct/construct.go
+++ b/pkg/construct/construct.go
@@ -254,8 +254,8 @@ func Construct(sc ServiceConfig, opts ...Option) (Service, error) {
 
 	// build read through fetchers
 	// TODO: add sender / publisher / linksystem / legacy systems
-	providerIndex := providerindex.NewProviderIndex(providersCache, findClient, publisher, nil)
-	claimLookup := claimlookup.WithCache(claimlookup.NewClaimLookup(http.DefaultClient), claimsCache)
+	providerIndex := providerindex.New(providersCache, findClient, publisher, nil)
+	claimLookup := claimlookup.WithCache(claimlookup.NewSimpleClaimLookup(http.DefaultClient), claimsCache)
 	blobIndexLookup := blobindexlookup.WithCache(
 		blobindexlookup.NewBlobIndexLookup(http.DefaultClient),
 		shardDagIndexesCache,

--- a/pkg/internal/link/link.go
+++ b/pkg/internal/link/link.go
@@ -1,0 +1,14 @@
+package link
+
+import (
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+)
+
+func ToCID(link ipld.Link) cid.Cid {
+	if cl, ok := link.(cidlink.Link); ok {
+		return cl.Cid
+	}
+	return cid.MustParse(link.String())
+}

--- a/pkg/internal/testutil/helpers.go
+++ b/pkg/internal/testutil/helpers.go
@@ -51,6 +51,7 @@ func RequireEqualDelegation(t *testing.T, expectedDelegation delegation.Delegati
 		require.Nil(t, actualDelegation)
 		return
 	}
+	require.NotNil(t, actualDelegation)
 	require.Equal(t, expectedDelegation.Issuer(), actualDelegation.Issuer())
 	require.Equal(t, expectedDelegation.Audience(), actualDelegation.Audience())
 	require.Equal(t, expectedDelegation.Capabilities(), actualDelegation.Capabilities())

--- a/pkg/service/blobindexlookup/cachinglookup.go
+++ b/pkg/service/blobindexlookup/cachinglookup.go
@@ -24,6 +24,8 @@ type cachingLookup struct {
 	cachingQueue       CachingQueue
 }
 
+var _ BlobIndexLookup = (*cachingLookup)(nil)
+
 // WithCache returns a blobIndexLookup that attempts to read blobs from the cache, and also caches providers asociated with index cids
 func WithCache(blobIndexLookup BlobIndexLookup, shardedDagIndexCache types.ShardedDagIndexStore, cachingQueue CachingQueue) BlobIndexLookup {
 	return &cachingLookup{

--- a/pkg/service/blobindexlookup/interface.go
+++ b/pkg/service/blobindexlookup/interface.go
@@ -10,6 +10,13 @@ import (
 	"github.com/storacha/indexing-service/pkg/types"
 )
 
+// BlobIndexLookup is a read through cache for fetching blob indexes
 type BlobIndexLookup interface {
+	// Find should:
+	// 1. attempt to read the sharded dag index from the cache from the encoded contextID
+	// 2. if not found, attempt to fetch the index from the provided URL. Store the result in cache
+	// 3. return the index
+	// 4. asyncronously, add records to the ProviderStore from the parsed blob index so that we can avoid future queries to IPNI for
+	// other multihashes in the index
 	Find(ctx context.Context, contextID types.EncodedContextID, provider model.ProviderResult, fetchURL url.URL, rng *metadata.Range) (blobindex.ShardedDagIndexView, error)
 }

--- a/pkg/service/blobindexlookup/simplelookup.go
+++ b/pkg/service/blobindexlookup/simplelookup.go
@@ -18,6 +18,8 @@ type simpleLookup struct {
 	httpClient *http.Client
 }
 
+var _ BlobIndexLookup = (*simpleLookup)(nil)
+
 func NewBlobIndexLookup(httpClient *http.Client) BlobIndexLookup {
 	return &simpleLookup{httpClient}
 }

--- a/pkg/service/claimlookup/cachinglookup_test.go
+++ b/pkg/service/claimlookup/cachinglookup_test.go
@@ -16,113 +16,178 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithCache__LookupClaim(t *testing.T) {
+func TestWithCache(t *testing.T) {
+	t.Run("LookupClaim", func(t *testing.T) {
+		// Create a cached claim
+		cachedClaim := testutil.RandomLocationDelegation()
+		notCachedClaim := testutil.RandomIndexDelegation()
 
-	// Create a test CID
-	cachedCid := testutil.RandomCID().(cidlink.Link).Cid
-	notCachedCid := testutil.RandomCID().(cidlink.Link).Cid
-	// Create a cached claim
-	cachedClaim := testutil.RandomLocationDelegation()
-	notCachedClaim := testutil.RandomIndexDelegation()
+		// Create a test CID
+		cachedCid := cachedClaim.Link().(cidlink.Link).Cid
+		notCachedCid := notCachedClaim.Link().(cidlink.Link).Cid
 
-	// sample error
-	anError := errors.New("something went wrong")
-	// Define test cases
-	testCases := []struct {
-		name          string
-		claimCid      cid.Cid
-		setErr        error
-		getErr        error
-		expectedErr   error
-		baseLookup    *mockClaimLookup
-		expectedClaim delegation.Delegation
-		finalState    map[string]delegation.Delegation
-	}{
-		{
-			name:          "Claim cached",
-			claimCid:      cachedCid,
-			expectedClaim: cachedClaim,
-			finalState: map[string]delegation.Delegation{
-				cachedCid.String(): cachedClaim,
-			},
-		},
-		{
-			name:          "Claim not cached, successful fetch",
-			claimCid:      notCachedCid,
-			expectedClaim: notCachedClaim,
-			finalState: map[string]delegation.Delegation{
-				cachedCid.String():    cachedClaim,
-				notCachedCid.String(): notCachedClaim,
-			},
-		},
-		{
-			name:          "Lookup error",
-			claimCid:      cachedCid,
-			expectedClaim: nil,
-			getErr:        anError,
-			expectedErr:   fmt.Errorf("reading from claim cache: %w", anError),
-			finalState: map[string]delegation.Delegation{
-				cachedCid.String(): cachedClaim,
-			},
-		},
-		{
-			name:          "Save cache error",
-			claimCid:      notCachedCid,
-			expectedClaim: nil,
-			setErr:        anError,
-			expectedErr:   fmt.Errorf("caching fetched claim: %w", anError),
-			finalState: map[string]delegation.Delegation{
-				cachedCid.String(): cachedClaim,
-			},
-		},
-		{
-			name:          "underlying lookup error",
-			claimCid:      notCachedCid,
-			expectedClaim: nil,
-			baseLookup:    &mockClaimLookup{nil, anError},
-			expectedErr:   fmt.Errorf("fetching underlying claim: %w", anError),
-			finalState: map[string]delegation.Delegation{
-				cachedCid.String(): cachedClaim,
-			},
-		},
-	}
-
-	// Run test cases
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			mockStore := &MockContentClaimsStore{
-				setErr: tc.setErr,
-				getErr: tc.getErr,
-				claims: map[string]delegation.Delegation{
+		// sample error
+		anError := errors.New("something went wrong")
+		// Define test cases
+		testCases := []struct {
+			name          string
+			claimCid      cid.Cid
+			setErr        error
+			getErr        error
+			expectedErr   error
+			baseLookup    *mockClaimLookup
+			expectedClaim delegation.Delegation
+			finalState    map[string]delegation.Delegation
+		}{
+			{
+				name:          "Claim cached",
+				claimCid:      cachedCid,
+				expectedClaim: cachedClaim,
+				finalState: map[string]delegation.Delegation{
 					cachedCid.String(): cachedClaim,
 				},
-			}
-			// generate a test server for requests
-			lookup := tc.baseLookup
-			if lookup == nil {
-				lookup = &mockClaimLookup{notCachedClaim, nil}
-			}
-			// Create ClaimLookup instance
-			cl := claimlookup.WithCache(lookup, mockStore)
+			},
+			{
+				name:          "Claim not cached, successful fetch",
+				claimCid:      notCachedCid,
+				expectedClaim: notCachedClaim,
+				finalState: map[string]delegation.Delegation{
+					cachedCid.String():    cachedClaim,
+					notCachedCid.String(): notCachedClaim,
+				},
+			},
+			{
+				name:          "Lookup error",
+				claimCid:      cachedCid,
+				expectedClaim: nil,
+				getErr:        anError,
+				expectedErr:   fmt.Errorf("reading from claim cache: %w", anError),
+				finalState: map[string]delegation.Delegation{
+					cachedCid.String(): cachedClaim,
+				},
+			},
+			{
+				name:          "Save cache error",
+				claimCid:      notCachedCid,
+				expectedClaim: nil,
+				setErr:        anError,
+				expectedErr:   fmt.Errorf("caching claim: %w", anError),
+				finalState: map[string]delegation.Delegation{
+					cachedCid.String(): cachedClaim,
+				},
+			},
+			{
+				name:          "underlying lookup error",
+				claimCid:      notCachedCid,
+				expectedClaim: nil,
+				baseLookup:    &mockClaimLookup{nil, anError},
+				expectedErr:   fmt.Errorf("fetching underlying claim: %w", anError),
+				finalState: map[string]delegation.Delegation{
+					cachedCid.String(): cachedClaim,
+				},
+			},
+		}
 
-			claim, err := cl.LookupClaim(context.Background(), tc.claimCid, *testutil.TestURL)
-			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
-			} else {
-				require.NoError(t, err)
-			}
-			testutil.RequireEqualDelegation(t, tc.expectedClaim, claim)
-			finalState := tc.finalState
-			if finalState == nil {
-				finalState = make(map[string]delegation.Delegation)
-			}
-			require.Equal(t, len(finalState), len(mockStore.claims))
-			for c, claim := range mockStore.claims {
-				expectedClaim := finalState[c]
-				testutil.RequireEqualDelegation(t, expectedClaim, claim)
-			}
-		})
-	}
+		// Run test cases
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mockStore := &MockContentClaimsStore{
+					setErr: tc.setErr,
+					getErr: tc.getErr,
+					claims: map[string]delegation.Delegation{
+						cachedCid.String(): cachedClaim,
+					},
+				}
+				// generate a test server for requests
+				lookup := tc.baseLookup
+				if lookup == nil {
+					lookup = &mockClaimLookup{notCachedClaim, nil}
+				}
+				// Create ClaimLookup instance
+				cl := claimlookup.WithCache(lookup, mockStore)
+
+				claim, err := cl.LookupClaim(context.Background(), tc.claimCid, *testutil.TestURL)
+				if tc.expectedErr != nil {
+					require.EqualError(t, err, tc.expectedErr.Error())
+				} else {
+					require.NoError(t, err)
+				}
+				testutil.RequireEqualDelegation(t, tc.expectedClaim, claim)
+				finalState := tc.finalState
+				if finalState == nil {
+					finalState = make(map[string]delegation.Delegation)
+				}
+				require.Equal(t, len(finalState), len(mockStore.claims))
+				for c, claim := range mockStore.claims {
+					expectedClaim := finalState[c]
+					testutil.RequireEqualDelegation(t, expectedClaim, claim)
+				}
+			})
+		}
+	})
+
+	t.Run("CacheClaim", func(t *testing.T) {
+		// sample error
+		anError := errors.New("something went wrong")
+		// Define test cases
+		testCases := []struct {
+			name        string
+			claim       delegation.Delegation
+			storeErr    error
+			lookupErr   error
+			expectedErr error
+			baseLookup  *mockClaimLookup
+		}{
+			{
+				name:        "Successful cache",
+				claim:       testutil.RandomLocationDelegation(),
+				storeErr:    nil,
+				lookupErr:   nil,
+				expectedErr: nil,
+			},
+			{
+				name:        "Failed cache",
+				claim:       testutil.RandomIndexDelegation(),
+				storeErr:    anError,
+				lookupErr:   nil,
+				expectedErr: fmt.Errorf("caching claim: %w", anError),
+			},
+			{
+				name:        "Failed lookup cache",
+				claim:       testutil.RandomIndexDelegation(),
+				storeErr:    nil,
+				lookupErr:   anError,
+				expectedErr: fmt.Errorf("caching claim in underlying cacher: %w", anError),
+			},
+		}
+
+		// Run test cases
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mockStore := &MockContentClaimsStore{
+					setErr: tc.storeErr,
+					claims: map[string]delegation.Delegation{},
+				}
+				// generate a test server for requests
+				lookup := tc.baseLookup
+				if lookup == nil {
+					lookup = &mockClaimLookup{tc.claim, tc.lookupErr}
+				}
+				// Create ClaimLookup instance
+				cl := claimlookup.WithCache(lookup, mockStore)
+				clc, ok := cl.(claimlookup.ClaimCacher)
+				require.True(t, ok)
+
+				err := clc.CacheClaim(context.Background(), tc.claim)
+				if tc.expectedErr != nil {
+					require.EqualError(t, err, tc.expectedErr.Error())
+				} else {
+					require.NoError(t, err)
+					testutil.RequireEqualDelegation(t, tc.claim, mockStore.claims[tc.claim.Link().String()])
+				}
+			})
+		}
+	})
 }
 
 // MockContentClaimsStore is a mock implementation of the ContentClaimsStore interface
@@ -160,6 +225,10 @@ func (m *MockContentClaimsStore) Set(ctx context.Context, claimCid cid.Cid, clai
 type mockClaimLookup struct {
 	claim delegation.Delegation
 	err   error
+}
+
+func (m *mockClaimLookup) CacheClaim(ctx context.Context, claim delegation.Delegation) error {
+	return m.err
 }
 
 func (m *mockClaimLookup) LookupClaim(ctx context.Context, claimCid cid.Cid, fetchURL url.URL) (delegation.Delegation, error) {

--- a/pkg/service/claimlookup/interface.go
+++ b/pkg/service/claimlookup/interface.go
@@ -8,6 +8,16 @@ import (
 	"github.com/storacha/go-ucanto/core/delegation"
 )
 
+// ClaimLookup is used to get full claims from a claim cid
 type ClaimLookup interface {
+	// LookupClaim should:
+	// 1. attempt to read the claim from the cache from the encoded contextID
+	// 2. if not found, attempt to fetch the claim from the provided URL. Store the result in cache
+	// 3. return the claim
 	LookupClaim(ctx context.Context, claimCid cid.Cid, fetchURL url.URL) (delegation.Delegation, error)
+}
+
+type ClaimCacher interface {
+	// CacheClaim writes the passed claim to the cache with default expiry.
+	CacheClaim(ctx context.Context, claim delegation.Delegation) error
 }

--- a/pkg/service/claimlookup/simplelookup.go
+++ b/pkg/service/claimlookup/simplelookup.go
@@ -16,8 +16,10 @@ type simpleLookup struct {
 	httpClient *http.Client
 }
 
-// NewClaimLookup creates a new ClaimLookup with the provided claimstore and HTTP client
-func NewClaimLookup(httpClient *http.Client) ClaimLookup {
+var _ ClaimLookup = (*simpleLookup)(nil)
+
+// NewSimpleClaimLookup creates a new ClaimLookup with the provided claimstore and HTTP client
+func NewSimpleClaimLookup(httpClient *http.Client) ClaimLookup {
 	return &simpleLookup{
 		httpClient: httpClient,
 	}

--- a/pkg/service/claimlookup/simplelookup_test.go
+++ b/pkg/service/claimlookup/simplelookup_test.go
@@ -46,7 +46,7 @@ func TestClaimLookup__LookupClaim(t *testing.T) {
 			testServer := httptest.NewServer(tc.handler)
 			defer func() { testServer.Close() }()
 			// Create ClaimLookup instance
-			cl := claimlookup.NewClaimLookup(testServer.Client())
+			cl := claimlookup.NewSimpleClaimLookup(testServer.Client())
 			claim, err := cl.LookupClaim(context.Background(), cid, *testutil.Must(url.Parse(testServer.URL))(t))
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())

--- a/pkg/service/providerindex/interface.go
+++ b/pkg/service/providerindex/interface.go
@@ -1,0 +1,29 @@
+package providerindex
+
+import (
+	"context"
+
+	"github.com/ipni/go-libipni/find/model"
+	meta "github.com/ipni/go-libipni/metadata"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multihash"
+)
+
+// ProviderIndex is a read/write interface to a local cache of providers that falls back to IPNI
+type ProviderIndex interface {
+	// Find should do the following
+	//  1. Read from the IPNI Storage cache to get a list of providers
+	//     a. If there is no record in cache, query IPNI, filter out any non-content claims metadata, and store
+	//     the resulting records in the cache
+	//     b. the are no records in the cache or IPNI, it can attempt to read from legacy systems -- Dynamo tables & content claims storage, synthetically constructing provider results
+	//  2. With returned provider results, filter additionally for claim type. If space dids are set, calculate an encodedcontextid's by hashing space DID and Hash, and filter for a matching context id
+	//     Future TODO: kick off a conversion task to update the recrds
+	Find(context.Context, QueryKey) ([]model.ProviderResult, error)
+	// Cache writes entries to the cache but does not publish/announce an
+	// advertisement for them. Entries expire after a pre-determined time.
+	Cache(ctx context.Context, provider peer.AddrInfo, contextID string, digests []multihash.Multihash, meta meta.Metadata) error
+	// Publish should do the following:
+	// 1. Write the entries to the cache with no expiration until publishing is complete
+	// 2. Generate an advertisement for the advertised hashes and publish/announce it
+	Publish(ctx context.Context, provider peer.AddrInfo, contextID string, digests []multihash.Multihash, meta meta.Metadata) error
+}

--- a/pkg/service/providerindex/remotesyncer.go
+++ b/pkg/service/providerindex/remotesyncer.go
@@ -3,9 +3,7 @@ package providerindex
 import (
 	"context"
 
-	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	mh "github.com/multiformats/go-multihash"
 	"github.com/storacha/indexing-service/pkg/internal/jobqueue"
 	"github.com/storacha/indexing-service/pkg/types"
@@ -61,10 +59,10 @@ func (rs *RemoteSyncer) HandleRemoteSync(ctx context.Context, head, prev ipld.Li
 				return
 			}
 		}
-		if ad.PreviousCid() == cid.Undef || ad.PreviousCid().String() == prev.String() {
+		if ad.PreviousID == nil || (prev != nil && ad.PreviousID.String() == prev.String()) {
 			break
 		}
-		cur = cidlink.Link{Cid: ad.PreviousCid()}
+		cur = ad.PreviousID
 	}
 
 	err := q.Shutdown(ctx)

--- a/pkg/service/providerindex/remotesyncer_test.go
+++ b/pkg/service/providerindex/remotesyncer_test.go
@@ -1,0 +1,172 @@
+package providerindex
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"iter"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipni/go-libipni/find/model"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/storacha/indexing-service/pkg/internal/bytemap"
+	"github.com/storacha/indexing-service/pkg/internal/testutil"
+	"github.com/storacha/indexing-service/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func dagCBORLink(t *testing.T, n ipld.Node) ipld.Link {
+	t.Helper()
+	buf := bytes.NewBuffer(nil)
+	err := dagcbor.Encode(n, buf)
+	require.NoError(t, err)
+	codec := uint64(multicodec.DagCbor)
+	digest := testutil.Must(multihash.Sum(buf.Bytes(), multihash.SHA2_256, -1))(t)
+	return cidlink.Link{Cid: cid.NewCidV1(codec, digest)}
+}
+
+func TestHandleRemoteSync(t *testing.T) {
+	ads := map[string]schema.Advertisement{}
+	ents := map[string]schema.EntryChunk{}
+	ipniStore := mockIpniStore{ads, ents}
+	providerStore := mockProviderStore{
+		data: bytemap.NewByteMap[multihash.Multihash, *valueExpirable[[]model.ProviderResult]](-1),
+	}
+
+	var hd ipld.Link
+	for range 5 {
+		ad := schema.Advertisement{}
+		if hd != nil {
+			ad.PreviousID = hd
+		}
+
+		var ec schema.EntryChunk
+		for range rand.IntN(100) {
+			digest := testutil.RandomMultihash()
+			ec.Entries = append(ec.Entries, digest)
+			err := providerStore.Set(context.Background(), digest, []model.ProviderResult{}, false)
+			require.NoError(t, err)
+		}
+		n := testutil.Must(ec.ToNode())(t)
+		eclnk := dagCBORLink(t, n)
+		ents[eclnk.String()] = ec
+		ad.Entries = eclnk
+
+		n = testutil.Must(ad.ToNode())(t)
+		adlink := dagCBORLink(t, n)
+		ads[adlink.String()] = ad
+		hd = adlink
+	}
+
+	prev := ads[hd.String()].PreviousID
+
+	syncer := NewRemoteSyncer(&providerStore, &ipniStore)
+	syncer.HandleRemoteSync(context.Background(), prev, nil)
+	requireExpirable(t, &providerStore, &ipniStore, hd, prev, false)
+	requireExpirable(t, &providerStore, &ipniStore, prev, nil, true)
+
+	syncer.HandleRemoteSync(context.Background(), hd, prev)
+	requireExpirable(t, &providerStore, &ipniStore, hd, nil, true)
+}
+
+func requireExpirable(t *testing.T, providerStore *mockProviderStore, ipniStore *mockIpniStore, head ipld.Link, tail ipld.Link, expirable bool) {
+	cur := head
+	for cur != tail {
+		ad, err := ipniStore.Advert(context.Background(), cur)
+		require.NoError(t, err)
+
+		for digest, err := range ipniStore.Entries(context.Background(), ad.Entries) {
+			require.NoError(t, err)
+			exp, err := providerStore.GetExpiration(context.Background(), digest)
+			require.NoError(t, err)
+			require.Equal(t, expirable, !exp.IsZero())
+		}
+		cur = ad.PreviousID
+	}
+}
+
+type mockIpniStore struct {
+	ads  map[string]schema.Advertisement
+	ents map[string]schema.EntryChunk
+}
+
+func (i *mockIpniStore) Advert(ctx context.Context, id datamodel.Link) (schema.Advertisement, error) {
+	ad, ok := i.ads[id.String()]
+	if !ok {
+		return schema.Advertisement{}, fmt.Errorf("not found: %s", id.String())
+	}
+	return ad, nil
+}
+
+func (i *mockIpniStore) Entries(ctx context.Context, root datamodel.Link) iter.Seq2[multihash.Multihash, error] {
+	return func(yield func(multihash.Multihash, error) bool) {
+		ent := i.ents[root.String()]
+		for _, digest := range ent.Entries {
+			yield(digest, nil)
+		}
+	}
+}
+
+var _ Store = (*mockIpniStore)(nil)
+
+type valueExpirable[T any] struct {
+	val T
+	exp time.Time
+}
+
+type mockProviderStore struct {
+	data bytemap.ByteMap[multihash.Multihash, *valueExpirable[[]model.ProviderResult]]
+}
+
+func (m *mockProviderStore) Get(ctx context.Context, key multihash.Multihash) ([]model.ProviderResult, error) {
+	val := m.data.Get(key)
+	if val == nil {
+		return nil, types.ErrKeyNotFound
+	}
+	if !val.exp.IsZero() && time.Now().After(val.exp) {
+		return nil, types.ErrKeyNotFound
+	}
+	return val.val, nil
+}
+
+func (m *mockProviderStore) Set(ctx context.Context, key multihash.Multihash, value []model.ProviderResult, expires bool) error {
+	var exp time.Time
+	if expires {
+		exp = exp.Add(time.Second * 30)
+	}
+	v := valueExpirable[[]model.ProviderResult]{value, exp}
+	m.data.Set(key, &v)
+	return nil
+}
+
+func (m *mockProviderStore) GetExpiration(ctx context.Context, key multihash.Multihash) (time.Time, error) {
+	val := m.data.Get(key)
+	if val == nil {
+		return time.Time{}, types.ErrKeyNotFound
+	}
+	return val.exp, nil
+}
+
+func (m *mockProviderStore) SetExpirable(ctx context.Context, key multihash.Multihash, expires bool) error {
+	val := m.data.Get(key)
+	if val == nil {
+		return types.ErrKeyNotFound
+	}
+	if expires {
+		val.exp = time.Now().Add(time.Second * 30)
+	} else {
+		val.exp = time.Time{}
+	}
+	return nil
+}
+
+var _ types.ProviderStore = (*mockProviderStore)(nil)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/result/ok"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/storacha/indexing-service/pkg/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishClaim(t *testing.T) {
+	t.Run("does not publish unknown claims", func(t *testing.T) {
+		claim, err := delegation.Delegate(
+			testutil.Alice,
+			testutil.Bob,
+			[]ucan.Capability[ok.Unit]{
+				ucan.NewCapability("unknown/claim", testutil.Mallory.DID().String(), ok.Unit{}),
+			},
+		)
+		require.NoError(t, err)
+		err = PublishClaim(context.Background(), nil, nil, nil, peer.AddrInfo{}, claim)
+		require.ErrorIs(t, err, ErrUnrecognizedClaim)
+	})
+}
+
+func TestCacheClaim(t *testing.T) {
+	t.Run("does not cache unknown claims", func(t *testing.T) {
+		claim, err := delegation.Delegate(
+			testutil.Alice,
+			testutil.Bob,
+			[]ucan.Capability[ok.Unit]{
+				ucan.NewCapability("unknown/claim", testutil.Mallory.DID().String(), ok.Unit{}),
+			},
+		)
+		require.NoError(t, err)
+		err = CacheClaim(context.Background(), nil, nil, nil, peer.AddrInfo{}, claim)
+		require.ErrorIs(t, err, ErrUnrecognizedClaim)
+	})
+}


### PR DESCRIPTION
This PR adds an interface that can be optionally implemented by `ClaimLookup` instances allowing claims to be written to their cache directly.

I also moved repeated interfaces out of `service.go` (but retained the comments).

IDK why but I decided to add tests for remote syncer here 🤷 

TODO: more tests