### PR TITLE
fix(simplelookup): update error message in test

### DIFF
--- a/pkg/aws/dynamoprovidercontexttable.go
+++ b/pkg/aws/dynamoprovidercontexttable.go
@@ -77,7 +77,7 @@ func (d *DynamoProviderContextTable) Put(ctx context.Context, p peer.ID, context
 		TableName: aws.String(d.tableName), Item: item,
 	})
 	if err != nil {
-		fmt.Errorf("storing item: %w", err)
+		return fmt.Errorf("storing item: %w", err)
 	}
 	return nil
 }

--- a/pkg/service/blobindexlookup/simplelookup_test.go
+++ b/pkg/service/blobindexlookup/simplelookup_test.go
@@ -43,7 +43,7 @@ func TestBlobIndexLookup__Find(t *testing.T) {
 		{
 			name:        "failure",
 			handler:     http.NotFound,
-			expectedErr: errors.New("failure response fetching index. status: 404 Not Found, message: 404 page not found\n"),
+			expectedErr: errors.New("failure response fetching index. status: 404 Not Found, message: 404 page not found, url: \n"),
 		},
 		{
 			name: "partial fetch from offset",


### PR DESCRIPTION
the test was failing because it was expecting the old error message.

I also fixed a call to `fmt.Errorf` in `dynamoprovidercontexttable`.