### PR TITLE
fix: issues when running indexing-service from the CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,7 +77,7 @@ func main() {
 							},
 							&cli.IntFlag{
 								Name:    "indexes-redis-db",
-								Aliases: []string{"c"},
+								Aliases: []string{"i"},
 								Usage:   "database number for indexes cache",
 								Value:   2,
 							},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,7 +94,14 @@ func main() {
 							var id principal.Signer
 							var err error
 							var opts []server.Option
-							if cCtx.String("private-key") != "" {
+
+							if !cCtx.IsSet("private-key") {
+								// generate a new private key if one is not provided
+								id, err = ed25519.Generate()
+								if err != nil {
+									return fmt.Errorf("generating server private key: %w", err)
+								}
+							} else {
 								id, err = ed25519.Parse(cCtx.String("private-key"))
 								if err != nil {
 									return fmt.Errorf("parsing server private key: %w", err)
@@ -109,8 +116,9 @@ func main() {
 										return fmt.Errorf("wrapping server DID: %w", err)
 									}
 								}
-								opts = append(opts, server.WithIdentity(id))
 							}
+
+							opts = append(opts, server.WithIdentity(id))
 
 							presolv, err := principalresolver.New(config.PrincipalMapping)
 							if err != nil {


### PR DESCRIPTION
A couple minor issues when running the service from the CLI:
- a typo in a flag alias
- add default behavior when a private key is not provided