### PR TITLE
fix: ipni store prefix

### DIFF
--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -93,7 +93,7 @@ func FromEnv(ctx context.Context) Config {
 
 	ipniStoreKeyPrefix := os.Getenv("IPNI_STORE_KEY_PREFIX")
 	if len(ipniStoreKeyPrefix) == 0 {
-		ipniStoreKeyPrefix = "/ipni/v1/ad/"
+		ipniStoreKeyPrefix = "ipni/v1/ad/"
 	}
 
 	peer, err := peer.IDFromPrivateKey(cryptoPrivKey)


### PR DESCRIPTION
Prevent double slash in public URL e.g. `https://staging-indexer-ipni-store-bucket.s3.us-west-2.amazonaws.com//ipni/v1/ad/head`