### PR TITLE
chore: allow access to legacy buckets and tables

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -72,9 +72,9 @@ resource "aws_lambda_function" "lambda" {
         PUBLIC_URL = "https://${aws_apigatewayv2_domain_name.custom_domain.domain_name}"
         IPNI_STORE_BUCKET_REGIONAL_DOMAIN = aws_s3_bucket.ipni_store_bucket.bucket_regional_domain_name
         CLAIM_STORE_BUCKET_NAME = aws_s3_bucket.claim_store_bucket.bucket
-        LEGACY_CLAIMS_TABLE_NAME = "prod-content-claims-claims-v1"
-        LEGACY_CLAIMS_BUCKET_NAME = "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8"
-        LEGACY_BLOCK_INDEX_TABLE_NAME = "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
+        LEGACY_CLAIMS_TABLE_NAME = data.aws_dynamodb_table.legacy_claims_table.id
+        LEGACY_CLAIMS_BUCKET_NAME = data.aws_s3_bucket.legacy_claims_bucket.id
+        LEGACY_BLOCK_INDEX_TABLE_NAME = data.aws_dynamodb_table.legacy_block_index_table.id
         LEGACY_DATA_BUCKET_URL = "https://carpark-${terraform.workspace == "prod" ? "prod" : "staging"}-0.r2.w3s.link"
         GOLOG_LOG_LEVEL = terraform.workspace == "prod" ? "error" : "debug"
     }

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -13,7 +13,11 @@ variable "legacy_claims_bucket_name" {
 variable "legacy_block_index_table_name" {
   description = "The name of the legacy block index DynamoDB table"
   type = string
-  default = "ep-v1-blocks-cars-position"
+  default = ""
+}
+
+locals {
+    inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
 }
 
 data "aws_s3_bucket" "legacy_claims_bucket" {
@@ -25,7 +29,7 @@ data "aws_dynamodb_table" "legacy_claims_table" {
 }
 
 data "aws_dynamodb_table" "legacy_block_index_table" {
-  name = "${terraform.workspace == "prod" ? "prod" : "staging"}-${var.legacy_block_index_table_name}"
+  name = local.inferred_legacy_block_index_table_name
 }
 
 data "aws_iam_policy_document" "lambda_legacy_dynamodb_query_document" {

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -1,0 +1,82 @@
+variable "legacy_claims_table_name" {
+  description = "The name of the DynamoDB table used by the legacy content-claims service"
+  type = string
+  default = "prod-content-claims-claims-v1"
+}
+
+variable "legacy_claims_bucket_name" {
+  description = "The name of the S3 bucket used by the legacy content-claims service"
+  type = string
+  default = "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8"
+}
+
+variable "legacy_block_index_table_name" {
+  description = "The name of the legacy block index DynamoDB table"
+  type = string
+  default = "ep-v1-blocks-cars-position"
+}
+
+data "aws_s3_bucket" "legacy_claims_bucket" {
+  bucket = var.legacy_claims_bucket_name
+}
+
+data "aws_dynamodb_table" "legacy_claims_table" {
+  name = var.legacy_claims_table_name
+}
+
+data "aws_dynamodb_table" "legacy_block_index_table" {
+  name = "${terraform.workspace == "prod" ? "prod" : "staging"}-${var.legacy_block_index_table_name}"
+}
+
+data "aws_iam_policy_document" "lambda_legacy_dynamodb_get_document" {
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.legacy_claims_table.arn,
+      data.aws_dynamodb_table.legacy_block_index_table.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_legacy_dynamodb_get" {
+  name        = "${terraform.workspace}-${var.app}-lambda-legacy-dynamodb-get"
+  description = "This policy will be used by the lambda to get data from legacy DynamoDB tables"
+  policy      = data.aws_iam_policy_document.lambda_legacy_dynamodb_get_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_legacy_dynamodb_get" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_legacy_dynamodb_get.arn
+}
+
+data "aws_iam_policy_document" "lambda_legacy_s3_get_document" {
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${data.aws_s3_bucket.legacy_claims_bucket.arn}/*"
+    ]
+  }
+  statement {
+    actions = [
+      "s3:ListBucket","s3:GetBucketLocation"
+    ]
+    resources = [
+      data.aws_s3_bucket.legacy_claims_bucket.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_legacy_s3_get" {
+  name        = "${terraform.workspace}-${var.app}-lambda_legacy_s3_get"
+  description = "This policy will be used by the lambda to get objects from legacy S3 buckets"
+  policy      = data.aws_iam_policy_document.lambda_legacy_s3_get_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_legacy_s3_get" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_legacy_s3_get.arn
+}

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -28,10 +28,10 @@ data "aws_dynamodb_table" "legacy_block_index_table" {
   name = "${terraform.workspace == "prod" ? "prod" : "staging"}-${var.legacy_block_index_table_name}"
 }
 
-data "aws_iam_policy_document" "lambda_legacy_dynamodb_get_document" {
+data "aws_iam_policy_document" "lambda_legacy_dynamodb_query_document" {
   statement {
     actions = [
-      "dynamodb:GetItem",
+      "dynamodb:Query",
     ]
     resources = [
       data.aws_dynamodb_table.legacy_claims_table.arn,
@@ -40,15 +40,15 @@ data "aws_iam_policy_document" "lambda_legacy_dynamodb_get_document" {
   }
 }
 
-resource "aws_iam_policy" "lambda_legacy_dynamodb_get" {
-  name        = "${terraform.workspace}-${var.app}-lambda-legacy-dynamodb-get"
-  description = "This policy will be used by the lambda to get data from legacy DynamoDB tables"
-  policy      = data.aws_iam_policy_document.lambda_legacy_dynamodb_get_document.json
+resource "aws_iam_policy" "lambda_legacy_dynamodb_query" {
+  name        = "${terraform.workspace}-${var.app}-lambda-legacy-dynamodb-query"
+  description = "This policy will be used by the lambda to query data from legacy DynamoDB tables"
+  policy      = data.aws_iam_policy_document.lambda_legacy_dynamodb_query_document.json
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_legacy_dynamodb_get" {
+resource "aws_iam_role_policy_attachment" "lambda_legacy_dynamodb_query" {
   role       = aws_iam_role.lambda_exec.name
-  policy_arn = aws_iam_policy.lambda_legacy_dynamodb_get.arn
+  policy_arn = aws_iam_policy.lambda_legacy_dynamodb_query.arn
 }
 
 data "aws_iam_policy_document" "lambda_legacy_s3_get_document" {


### PR DESCRIPTION
ref #53 

Add the required policies to allow `indexing-service` access legacy resources. Namely:
- `content-claims` DynamoDB table and S3 bucket
- block index table