### PR TITLE
fix: error code on query failure

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -168,7 +168,7 @@ func GetClaimsHandler(service types.Querier) http.HandlerFunc {
 		for _, mhString := range mhStrings {
 			_, bytes, err := multibase.Decode(mhString)
 			if err != nil {
-				http.Error(w, fmt.Sprintf("invalid multibase encoding: %s", err.Error()), 400)
+				http.Error(w, fmt.Sprintf("invalid multibase encoding: %s", err.Error()), http.StatusBadRequest)
 				return
 			}
 			hashes = append(hashes, bytes)
@@ -183,7 +183,7 @@ func GetClaimsHandler(service types.Querier) http.HandlerFunc {
 		for _, spaceString := range spaceStrings {
 			space, err := did.Parse(spaceString)
 			if err != nil {
-				http.Error(w, fmt.Sprintf("invalid did: %s", err.Error()), 400)
+				http.Error(w, fmt.Sprintf("invalid did: %s", err.Error()), http.StatusBadRequest)
 				return
 			}
 			spaces = append(spaces, space)
@@ -196,7 +196,7 @@ func GetClaimsHandler(service types.Querier) http.HandlerFunc {
 			},
 		})
 		if err != nil {
-			http.Error(w, fmt.Sprintf("processing query: %s", err.Error()), 400)
+			http.Error(w, fmt.Sprintf("processing query: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
Any error returned from the query engine is a server error - we've already validated the client sent parameters, it's no longer possible for the request to be considered bad.

I also switched magic constant `400` out for `http.StatusBadRequest` for readability.