### PR TITLE
chore: upgrade storacha/go-metadata library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/storacha/go-capabilities v0.0.0-20241030160329-4cf19ffc732d
-	github.com/storacha/go-metadata v0.0.0-20241031171938-8f3343b7ce5a
+	github.com/storacha/go-metadata v0.0.0-20241216142904-a60e20043cef
 	github.com/storacha/go-ucanto v0.1.1-0.20241028163940-34de8cd912bb
 	github.com/storacha/ipni-publisher v0.0.0-20241112152400-07a540928427
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -651,8 +651,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/storacha/go-capabilities v0.0.0-20241030160329-4cf19ffc732d h1:zcRQSf/3GY/R/wC1W0DKxTGUacsZuwIwhGZH63XWMDE=
 github.com/storacha/go-capabilities v0.0.0-20241030160329-4cf19ffc732d/go.mod h1:vHqUkLGC11Fhio/2qBJkK8MmA4q1t7DaRVdTIo0UHhE=
-github.com/storacha/go-metadata v0.0.0-20241031171938-8f3343b7ce5a h1:c1eCKRLOoNw1oCk7fOUgNArvJlQZYai1QgZOHHAubL4=
-github.com/storacha/go-metadata v0.0.0-20241031171938-8f3343b7ce5a/go.mod h1:HKKrwNQRGo731eC1ourP1ISRBR/Q9CYvbtpSz9yAu6o=
+github.com/storacha/go-metadata v0.0.0-20241216142904-a60e20043cef h1:dWRrteSgq7yIYtKagW/Myk9EZEZqQPk9vukV6qdB8KA=
+github.com/storacha/go-metadata v0.0.0-20241216142904-a60e20043cef/go.mod h1:7iJTSo9FugQ3EPjkR5C4sTHfNv8pxSwGAIbHlFhIrx0=
 github.com/storacha/go-ucanto v0.1.1-0.20241028163940-34de8cd912bb h1:lFwFtMjgt162ot9pnu230haLjRQ1rqwJOIAyywOqAX8=
 github.com/storacha/go-ucanto v0.1.1-0.20241028163940-34de8cd912bb/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
 github.com/storacha/ipni-publisher v0.0.0-20241112152400-07a540928427 h1:RoP1oLKNH4OXA37h4XgZIPSgFyyRuP3vM4DLbzjc2hk=


### PR DESCRIPTION
Upgrade [storacha/go-metadata](https://github.com/storacha/go-metadata) library to get the latest fixes to the schema definition and the marshalling/unmarshalling logic. 