### PR TITLE
fix: don't break when unmarshalling empty peer.ID

### DIFF
--- a/pkg/providerresults/providerresults.go
+++ b/pkg/providerresults/providerresults.go
@@ -33,6 +33,11 @@ func init() {
 }
 
 func bytesToPeerID(data []byte) (interface{}, error) {
+	if len(data) == 0 {
+		emptyID := peer.ID("")
+		return &emptyID, nil
+	}
+
 	id, err := peer.IDFromBytes(data)
 	return &id, err
 }

--- a/pkg/providerresults/providerresults_test.go
+++ b/pkg/providerresults/providerresults_test.go
@@ -56,3 +56,35 @@ func TestProviderResults__Equals(t *testing.T) {
 		})
 	}
 }
+
+func TestSerialization(t *testing.T) {
+	randomResult := testutil.RandomProviderResult()
+
+	testCases := []struct {
+		name       string
+		testResult model.ProviderResult
+	}{
+		{
+			name:       "random result",
+			testResult: randomResult,
+		},
+		{
+			name: "empty peer ID",
+			testResult: model.ProviderResult{
+				ContextID: randomResult.ContextID,
+				Metadata:  randomResult.Metadata,
+				Provider: &peer.AddrInfo{
+					ID:    "",
+					Addrs: randomResult.Provider.Addrs,
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled := testutil.Must(providerresults.MarshalCBOR([]model.ProviderResult{tc.testResult}))(t)
+			unmarshalled := testutil.Must(providerresults.UnmarshalCBOR(marshalled))(t)
+			require.Equal(t, tc.testResult, unmarshalled[0])
+		})
+	}
+}


### PR DESCRIPTION
It is expected for `ProviderResult.Provider.ID` to be empty in location, index and equals claims, as only the `Addrs` field of `peer.AddrInfo` is used in that case.