### PR TITLE
feat: deploy to prod automatically on successful releases

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,8 +46,8 @@ jobs:
       - uses: opentofu/setup-opentofu@v1
       - uses: actions/setup-go@v5
 
+      # always deploy to staging
       - name: Set Staging Environment Variables
-        if: startsWith(github.ref, 'refs/tags/') != true
         run: |
           echo "ENV=staging" >> $GITHUB_ENV
           echo "TF_WORKSPACE=staging" >> $GITHUB_ENV

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,8 +11,11 @@ on:
       - "cmd/**"
       - "deploy/**"
       - "pkg/**"
-      - "version.json"
   pull_request:
+    branches: ["main"]
+  workflow_run:
+    workflows: [Releaser]
+    types: [completed]
     branches: ["main"]
   workflow_dispatch:
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           tofu -chdir="deploy/app" init
 
-      - name: Ruild Go Apps    
+      - name: Build Go Apps
         run: |
           touch .env
           make lambdas

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -54,14 +54,6 @@ jobs:
           echo "TF_VAR_private_key=${{ secrets.STAGING_PRIVATE_KEY }}" >> $GITHUB_ENV
           echo "TF_VAR_did=did:web:staging.indexer.storacha.network" >> $GITHUB_ENV
 
-      - name: Set Production Environment Variables
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo "ENV=production" >> $GITHUB_ENV
-          echo "TF_WORKSPACE=prod" >> $GITHUB_ENV
-          echo "TF_VAR_private_key=${{ secrets.PROD_PRIVATE_KEY }}" >> $GITHUB_ENV
-          echo "TF_VAR_did=did:web:indexer.storacha.network" >> $GITHUB_ENV
-          
       - name: Tofu Init
         run: |
           tofu -chdir="deploy/app" init
@@ -78,5 +70,19 @@ jobs:
 
       - name: Terraform Apply
         if: github.event_name != 'pull_request'
+        run: |
+          tofu -chdir="deploy/app" apply -input=false --auto-approve
+
+      # deploy to prod on new releases
+      - name: Set Production Environment Variables
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+        run: |
+          echo "ENV=production" >> $GITHUB_ENV
+          echo "TF_WORKSPACE=prod" >> $GITHUB_ENV
+          echo "TF_VAR_private_key=${{ secrets.PROD_PRIVATE_KEY }}" >> $GITHUB_ENV
+          echo "TF_VAR_did=did:web:indexer.storacha.network" >> $GITHUB_ENV
+
+      - name: Deploy to prod
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
         run: |
           tofu -chdir="deploy/app" apply -input=false --auto-approve


### PR DESCRIPTION
We are creating releases automatically whenever a change to `version.json` is pushed. We expected the new tag would trigger our `Terraform` workflow, but it looks like [workflows using `GITHUB_TOKEN` cannot trigger other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow:~:text=When%20you%20use,push%20events%20occur.).

I want to try using the `workflow_run` event as a potential workaround.