### PR TITLE
fix: link the stage with the deployment to make the API available

### DIFF
--- a/deploy/app/gateway.tf
+++ b/deploy/app/gateway.tf
@@ -71,13 +71,14 @@ resource "aws_apigatewayv2_integration" "postclaims" {
 }
 
 resource "aws_apigatewayv2_deployment" "deployment" {
-  depends_on = [aws_apigatewayv2_integration.getclaims, aws_apigatewayv2_integration.getroot, aws_apigatewayv2_integration.postclaims]
+  depends_on = [aws_apigatewayv2_integration.getclaim, aws_apigatewayv2_integration.getclaims, aws_apigatewayv2_integration.getroot, aws_apigatewayv2_integration.postclaims]
   triggers = {
     redeployment = sha1(join(",", [
       jsonencode(aws_apigatewayv2_integration.getclaim),
-      jsonencode(aws_apigatewayv2_integration.postclaims),
       jsonencode(aws_apigatewayv2_integration.getclaims),
+      jsonencode(aws_apigatewayv2_integration.postclaims),
       jsonencode(aws_apigatewayv2_integration.getroot),
+      jsonencode(aws_apigatewayv2_route.getclaim),
       jsonencode(aws_apigatewayv2_route.getclaims),
       jsonencode(aws_apigatewayv2_route.getroot),
       jsonencode(aws_apigatewayv2_route.postclaims),
@@ -134,6 +135,8 @@ resource "aws_apigatewayv2_domain_name" "custom_domain" {
 resource "aws_apigatewayv2_stage" "stage" {
   api_id = aws_apigatewayv2_api.api.id
   name   = "$default"
+  deployment_id = aws_apigatewayv2_deployment.deployment.id
+
   lifecycle {
     create_before_destroy = true
   }

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -24,7 +24,7 @@ provider "aws" {
       "Environment" = terraform.workspace
       "ManagedBy"   = "OpenTofu"
       Owner         = "storacha"
-      Team          = "Storacha Engineer"
+      Team          = "Storacha Engineering"
       Organization  = "Storacha"
       Project       = "${var.app}"
     }

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -21,7 +21,7 @@ provider "aws" {
       "Environment" = terraform.workspace
       "ManagedBy"   = "OpenTofu"
       Owner         = "storacha"
-      Team          = "Storacha Engineer"
+      Team          = "Storacha Engineering"
       Organization  = "Storacha"
       Project       = "${var.app}"
     }


### PR DESCRIPTION
We were creating the API Gateway deployment and stage properly, but missed associating them both, which prevented the API from being available.