### PR TITLE
chore: upgrade goreleaser to v2

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,7 +1,7 @@
 name: GoReleaser
 on:
   release:
-    types: [ published ]
+    types: [published]
   workflow_dispatch:
   workflow_run:
     workflows: [Releaser]
@@ -18,9 +18,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20.x"
+          go-version: "1.23.x"
       - name: Release Binaries
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - main: ./cmd
     binary: indexing-service
@@ -31,4 +33,4 @@ archives:
 release:
   mode: keep-existing
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Upgrade `goreleaser/goreleaser-action` to v6, which will use goreleaser v2, and the Go version being used. Minor adjustments to the config were required according to [the docs](https://goreleaser.com/deprecations/#removed-in-v2).

This should solve the error in the GoReleaser workflow. It complains because the go version line in `go.mod` (which currently reads `go 1.23.2`) shouldn't include the patch number. However, the patch is supported in `go.mod` since Go 1.21.