### PR TITLE
feat(legacy): add carpark fallback

### DIFF
--- a/pkg/aws/bucketfallbackmapp.go
+++ b/pkg/aws/bucketfallbackmapp.go
@@ -1,0 +1,82 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	multihash "github.com/multiformats/go-multihash"
+	"github.com/storacha/go-capabilities/pkg/assert"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/principal"
+	"github.com/storacha/indexing-service/pkg/types"
+)
+
+type ContentToClaimsMapper interface {
+	GetClaims(ctx context.Context, contentHash multihash.Multihash) ([]cid.Cid, error)
+}
+
+type BucketFallbackMapper struct {
+	id               principal.Signer
+	carparkPublicURL url.URL
+	baseMapper       ContentToClaimsMapper
+}
+
+func NewBucketFallbackMapper(id principal.Signer, carparkPublicURL url.URL, baseMapper ContentToClaimsMapper) BucketFallbackMapper {
+	return BucketFallbackMapper{
+		id:               id,
+		carparkPublicURL: carparkPublicURL,
+		baseMapper:       baseMapper,
+	}
+}
+
+func (cfm BucketFallbackMapper) GetClaims(ctx context.Context, contentHash multihash.Multihash) ([]cid.Cid, error) {
+	claims, err := cfm.baseMapper.GetClaims(ctx, contentHash)
+	if err == nil || !errors.Is(err, types.ErrKeyNotFound) {
+		return claims, err
+	}
+
+	resp, err := http.DefaultClient.Head(cfm.carparkPublicURL.JoinPath(toBlobKey(contentHash)).String())
+	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, types.ErrKeyNotFound
+	}
+	size := uint64(resp.ContentLength)
+	delegation, err := assert.Location.Delegate(
+		cfm.id,
+		cfm.id,
+		cfm.id.DID().String(),
+		assert.LocationCaveats{
+			Content:  assert.FromHash(contentHash),
+			Location: []url.URL{*cfm.carparkPublicURL.JoinPath(toBlobKey(contentHash))},
+			Range:    &assert.Range{Offset: 0, Length: &size},
+		},
+		delegation.WithExpiration(int(time.Now().Add(time.Hour).Unix())),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("generating delegation: %w", err)
+	}
+	delegationData, err := io.ReadAll(delegation.Archive())
+	if err != nil {
+		return nil, fmt.Errorf("serializing delegation: %w", err)
+	}
+	c, err := cid.Prefix{
+		Version:  1,
+		Codec:    cid.Raw,
+		MhType:   multihash.IDENTITY,
+		MhLength: len(delegationData),
+	}.Sum(delegationData)
+	if err != nil {
+		return nil, fmt.Errorf("generating identity cid: %w", err)
+	}
+	return []cid.Cid{c}, err
+}
+
+func toBlobKey(contentHash multihash.Multihash) string {
+	mhStr := contentHash.B58String()
+	return fmt.Sprintf("%s/%s.blob", mhStr)
+}

--- a/pkg/aws/bucketfallbackmapper_test.go
+++ b/pkg/aws/bucketfallbackmapper_test.go
@@ -1,0 +1,195 @@
+package aws_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-capabilities/pkg/assert"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/indexing-service/pkg/aws"
+	"github.com/storacha/indexing-service/pkg/bytemap"
+	"github.com/storacha/indexing-service/pkg/internal/digestutil"
+	"github.com/storacha/indexing-service/pkg/internal/testutil"
+	"github.com/storacha/indexing-service/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketFallbackMapper(t *testing.T) {
+	ctx := context.Background()
+	baseMap := bytemap.NewByteMap[multihash.Multihash, cidsAndError](-1)
+	responses := bytemap.NewByteMap[multihash.Multihash, resp](-1)
+	signer := testutil.RandomSigner()
+	serverURL := testutil.Must(url.Parse("http://localhost:8888"))(t)
+
+	hasBaseResultsHash := testutil.RandomMultihash()
+	hasBaseResultCids := []cid.Cid{testutil.RandomCID().(cidlink.Link).Cid}
+	baseMap.Set(hasBaseResultsHash, cidsAndError{hasBaseResultCids, nil})
+
+	hasBaseErrorHash := testutil.RandomMultihash()
+	hasBaseError := errors.New("something went real wrong")
+	baseMap.Set(hasBaseErrorHash, cidsAndError{nil, hasBaseError})
+
+	hasNonSuccessHash := testutil.RandomMultihash()
+	responses.Set(hasNonSuccessHash, resp{0, http.StatusInternalServerError})
+
+	hasSuccessHash := testutil.RandomMultihash()
+	hasSuccessContentLength := uint64(500)
+	responses.Set(hasSuccessHash, resp{int64(hasSuccessContentLength), http.StatusOK})
+	hasSuccessClaim := testutil.Must(assert.Location.Delegate(
+		signer,
+		signer,
+		signer.DID().String(),
+		assert.LocationCaveats{
+			Content: assert.FromHash(hasSuccessHash),
+			Location: []url.URL{
+				*serverURL.JoinPath(digestutil.Format(hasSuccessHash), fmt.Sprintf("%s.blob", digestutil.Format(hasSuccessHash))),
+			},
+			Range: &assert.Range{
+				Offset: 0,
+				Length: &hasSuccessContentLength,
+			},
+		},
+		delegation.WithNoExpiration(),
+	))(t)
+
+	data := testutil.Must(io.ReadAll(hasSuccessClaim.Archive()))(t)
+
+	hasSuccessCids := []cid.Cid{testutil.Must(cid.Prefix{
+		Version:  1,
+		Codec:    uint64(multicodec.Car),
+		MhType:   multihash.IDENTITY,
+		MhLength: int(hasSuccessContentLength),
+	}.Sum(data))(t)}
+
+	testCases := []struct {
+		name          string
+		hash          multihash.Multihash
+		expectedCids  []cid.Cid
+		expectedErr   error
+		expectedClaim delegation.Delegation
+	}{
+		{
+			name:         "base mapper has results",
+			hash:         hasBaseResultsHash,
+			expectedCids: hasBaseResultCids,
+		},
+		{
+			name:        "base mapper has error other than not found",
+			hash:        hasBaseErrorHash,
+			expectedErr: hasBaseError,
+		},
+		{
+			name:        "non 200 status code from fallback bucket",
+			hash:        hasNonSuccessHash,
+			expectedErr: types.ErrKeyNotFound,
+		},
+		{
+			name:          "200 status code on head generates claim",
+			hash:          hasSuccessHash,
+			expectedCids:  hasSuccessCids,
+			expectedClaim: hasSuccessClaim,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			doneErr := make(chan error, 1)
+			mux := http.NewServeMux()
+			mux.Handle("/{multihash1}/{multihash2}", mockServer{responses})
+			server := &http.Server{
+				Addr:    serverURL.Host,
+				Handler: mux,
+			}
+			go func() {
+				doneErr <- server.ListenAndServe()
+			}()
+			bucketFallbackMapper := aws.NewBucketFallbackMapper(signer, serverURL, mockMapper{baseMap}, func() []delegation.Option {
+				return []delegation.Option{delegation.WithNoExpiration()}
+			})
+			cids, err := bucketFallbackMapper.GetClaims(ctx, testCase.hash)
+			if testCase.expectedErr != nil {
+				require.ErrorIs(t, err, testCase.expectedErr)
+				require.Len(t, cids, 0)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedCids, cids)
+				if testCase.expectedClaim != nil {
+					require.Len(t, cids, 1)
+					require.Equal(t, cids[0].Prefix().MhType, uint64(multihash.IDENTITY))
+					decoded := testutil.Must(multihash.Decode(cids[0].Hash()))(t)
+					claim := testutil.Must(delegation.Extract(decoded.Digest))(t)
+					testutil.RequireEqualDelegation(t, testCase.expectedClaim, claim)
+				}
+			}
+			require.NoError(t, server.Shutdown(ctx))
+			select {
+			case <-ctx.Done():
+				t.Fatal("did not complete shutdown")
+			case err := <-doneErr:
+				require.ErrorIs(t, err, http.ErrServerClosed)
+			}
+		})
+	}
+}
+
+type resp struct {
+	contentLength int64
+	status        int
+}
+
+type mockServer struct {
+	hashes bytemap.ByteMap[multihash.Multihash, resp]
+}
+
+// ServeHTTP implements http.Handler.
+func (m mockServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "HEAD" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	mhString := r.PathValue("multihash1")
+	mhString2 := r.PathValue("multihash2")
+	mhTrimmed, hadSuffix := strings.CutSuffix(mhString2, ".blob")
+	if mhString != mhTrimmed || !hadSuffix || mhString == "" {
+		http.Error(w, "invalid multihash", http.StatusBadRequest)
+		return
+	}
+	mh, err := digestutil.Parse(mhString)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("parsing multihash: %s", err.Error()), http.StatusBadRequest)
+	}
+	if !m.hashes.Has(mh) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+	resp := m.hashes.Get(mh)
+	w.Header().Add("Content-Length", strconv.FormatInt(resp.contentLength, 10))
+	w.WriteHeader(resp.status)
+}
+
+type cidsAndError struct {
+	cids []cid.Cid
+	err  error
+}
+
+type mockMapper struct {
+	contentMap bytemap.ByteMap[multihash.Multihash, cidsAndError]
+}
+
+// GetClaims implements aws.ContentToClaimsMapper.
+func (m mockMapper) GetClaims(ctx context.Context, contentHash multihash.Multihash) ([]cid.Cid, error) {
+	if !m.contentMap.Has(contentHash) {
+		return nil, types.ErrKeyNotFound
+	}
+	resp := m.contentMap.Get(contentHash)
+	return resp.cids, resp.err
+}

--- a/pkg/construct/construct.go
+++ b/pkg/construct/construct.go
@@ -343,7 +343,7 @@ func Construct(sc ServiceConfig, opts ...Option) (Service, error) {
 		if !strings.Contains(cfg.legacyClaimsUrl, service.ClaimUrlPlaceholder) {
 			return nil, fmt.Errorf("legacy claims url %s must contain the claim placeholder %s", cfg.legacyClaimsUrl, service.ClaimUrlPlaceholder)
 		}
-		legacyFinder := contentclaims.WithCache(contentclaims.WithStore(contentclaims.NewNotFoundFinder(), cfg.legacyClaimsBucket), claimsCache)
+		legacyFinder := contentclaims.WithIdentityCids(contentclaims.WithCache(contentclaims.WithStore(contentclaims.NewNotFoundFinder(), cfg.legacyClaimsBucket), claimsCache))
 		legacyClaims, err = providerindex.NewLegacyClaimsStore(cfg.legacyClaimsMapper, legacyFinder, cfg.legacyClaimsUrl)
 		if err != nil {
 			return nil, fmt.Errorf("creating legacy claims store: %w", err)

--- a/pkg/service/contentclaims/identitycidfinder.go
+++ b/pkg/service/contentclaims/identitycidfinder.go
@@ -1,0 +1,39 @@
+package contentclaims
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-ucanto/core/delegation"
+)
+
+type identityCidFinder struct {
+	finder Finder
+}
+
+var _ Finder = (*cachingFinder)(nil)
+
+// WithIdentityCids augments a ClaimFinder with claims retrieved automatically whenever an identity CID is used
+func WithIdentityCids(finder Finder) Finder {
+	return &identityCidFinder{finder}
+}
+
+// Find attempts to fetch a claim from either the permenant storage or via the provided URL
+func (idf *identityCidFinder) Find(ctx context.Context, id ipld.Link, fetchURL url.URL) (delegation.Delegation, error) {
+
+	if cidLink, ok := id.(cidlink.Link); ok {
+		if cidLink.Cid.Prefix().MhType == multihash.IDENTITY {
+			dh, err := multihash.Decode(cidLink.Cid.Hash())
+			if err != nil {
+				return nil, err
+			}
+			return delegation.Extract(dh.Digest)
+		}
+	}
+
+	// attempt to fetch the claim from the underlying claim finder
+	return idf.finder.Find(ctx, id, fetchURL)
+}

--- a/pkg/service/contentclaims/identitycidfinder_test.go
+++ b/pkg/service/contentclaims/identitycidfinder_test.go
@@ -1,0 +1,86 @@
+package contentclaims_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	multihash "github.com/multiformats/go-multihash/core"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/indexing-service/pkg/internal/testutil"
+	"github.com/storacha/indexing-service/pkg/service/contentclaims"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentityCidFinder__Find(t *testing.T) {
+	// Create a cached claim
+	identityCidClaim := testutil.RandomLocationDelegation()
+	notIdentityCidClaim := testutil.RandomIndexDelegation()
+
+	identityCiddata := testutil.Must(io.ReadAll(identityCidClaim.Archive()))(t)
+
+	// Create a test CID
+	identityCid := cidlink.Link{Cid: testutil.Must(cid.Prefix{
+		Version:  1,
+		Codec:    cid.Raw,
+		MhType:   multihash.IDENTITY,
+		MhLength: len(identityCiddata),
+	}.Sum(identityCiddata))(t)}
+	notIdentityCid := notIdentityCidClaim.Link()
+
+	// sample error
+	anError := errors.New("something went wrong")
+	// Define test cases
+	testCases := []struct {
+		name          string
+		claimCid      ipld.Link
+		getErr        error
+		expectedErr   error
+		baseFinder    *mockFinder
+		expectedClaim delegation.Delegation
+	}{
+		{
+			name:          "identity cid",
+			claimCid:      identityCid,
+			expectedClaim: identityCidClaim,
+		},
+		{
+			name:          "not identity cid, successful fetch",
+			claimCid:      notIdentityCid,
+			expectedClaim: notIdentityCidClaim,
+		},
+		{
+			name:          "underlying find error",
+			claimCid:      notIdentityCid,
+			expectedClaim: nil,
+			baseFinder:    &mockFinder{nil, anError},
+			expectedErr:   anError,
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// generate a test server for requests
+			finder := tc.baseFinder
+			if finder == nil {
+				finder = &mockFinder{notIdentityCidClaim, nil}
+			}
+			// Create ClaimLookup instance
+			cl := contentclaims.WithIdentityCids(finder)
+
+			claim, err := cl.Find(context.Background(), tc.claimCid, *testutil.TestURL)
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			testutil.RequireEqualDelegation(t, tc.expectedClaim, claim)
+		})
+	}
+}

--- a/pkg/service/contentclaims/service.go
+++ b/pkg/service/contentclaims/service.go
@@ -55,6 +55,6 @@ func (cs *ClaimService) Publish(ctx context.Context, claim delegation.Delegation
 }
 
 func New(store types.ContentClaimsStore, cache types.ContentClaimsCache, finder Finder) *ClaimService {
-	f := WithCache(WithStore(finder, store), cache)
+	f := WithIdentityCids(WithCache(WithStore(finder, store), cache))
 	return &ClaimService{store, cache, f}
 }


### PR DESCRIPTION
# Goals

Return location claims that were never published properly on the blob protocol from ~May - November 2024
fix #63

# Implementation

Essentially this ports https://github.com/storacha/blob-fetcher/pull/14

- When no legacy claims are found in the legacy claims bucket, check if the cid in question has an uploaded blob in carpark (via head request)
- if present, generate a location claim on demand, in much the same way we do for data pre-blob protocol data (reading from the blob-index table)
- however, here we fold into the normal indexing query process, and the way we accomplish this is via identity CIDs. Which is... a bit funky, but seems the simplest mechanism for making everything work together :)

# For Discussion

TODO:
- test for bucketFallbackMapper
- maybe integration test the whole thing