### PR TITLE
chore(terraform): deploy staging to a different region

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+    paths:
+      - ".github/workflows/deploy.yml"
+      - "cmd/**"
+      - "deploy/**"
+      - "pkg/**"
+  pull_request:
+    branches: [main]
+  workflow_run:
+    workflows: [Releaser]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  # always deploy to staging
+  staging:
+    uses: ./.github/workflows/terraform.yml
+    with:
+      env: staging
+      workspace: staging
+      did: did:web:staging.indexer.storacha.network
+      apply: ${{ github.event_name != 'pull_request' }}
+    secrets:
+      aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+      aws-region: ${{ secrets.STAGING_AWS_REGION }}
+      private-key: ${{ secrets.STAGING_PRIVATE_KEY }}
+
+  # deploy to prod on new releases
+  production:
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/terraform.yml
+    with:
+      env: production
+      workspace: prod
+      did: did:web:indexer.storacha.network
+      apply: true
+    secrets:
+      aws-account-id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
+      aws-region: ${{ secrets.PROD_AWS_REGION }}
+      private-key: ${{ secrets.PROD_PRIVATE_KEY }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -30,6 +30,10 @@ concurrency:
 env:
   AWS_ACCOUNT_ID: ${{ secrets.aws-account-id }}
   AWS_REGION: ${{ secrets.aws-region }}
+  ENV: ${{ inputs.env }}
+  TF_WORKSPACE: ${{ inputs.workspace }}
+  TF_VAR_private_key: ${{ secrets.private-key }}
+  TF_VAR_did: ${{ inputs.did }}
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -44,18 +48,11 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-region: ${{ inputs.aws-region }}
-          role-to-assume: arn:aws:iam::${{ secrets.aws-account-id }}:role/terraform-ci
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/terraform-ci
 
       - uses: opentofu/setup-opentofu@v1
       - uses: actions/setup-go@v5
-
-      - name: Set Environment Variables
-        run: |
-          echo "ENV=${{ inputs.env }}" >> $GITHUB_ENV
-          echo "TF_WORKSPACE=${{ inputs.workspace }}" >> $GITHUB_ENV
-          echo "TF_VAR_private_key=${{ secrets.private-key }}" >> $GITHUB_ENV
-          echo "TF_VAR_did=${{ inputs.did }}" >> $GITHUB_ENV
 
       - name: Tofu Init
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,31 +1,35 @@
 name: Terraform
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "*"
-    paths:
-      - ".github/workflows/terraform.yml"
-      - "cmd/**"
-      - "deploy/**"
-      - "pkg/**"
-  pull_request:
-    branches: ["main"]
-  workflow_run:
-    workflows: [Releaser]
-    types: [completed]
-    branches: ["main"]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      env:
+        required: true
+        type: string
+      workspace:
+        required: true
+        type: string
+      did:
+        required: true
+        type: string
+      apply:
+        required: true
+        type: boolean
+    secrets:
+      aws-account-id:
+        required: true
+      aws-region:
+        required: true
+      private-key:
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
-  AWS_ACCOUNT_ID: ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}
-  AWS_REGION: us-west-2
+  AWS_ACCOUNT_ID: ${{ secrets.aws-account-id }}
+  AWS_REGION: ${{ secrets.aws-region }}
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -40,19 +44,18 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}:role/terraform-ci
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: arn:aws:iam::${{ secrets.aws-account-id }}:role/terraform-ci
 
       - uses: opentofu/setup-opentofu@v1
       - uses: actions/setup-go@v5
 
-      # always deploy to staging
-      - name: Set Staging Environment Variables
+      - name: Set Environment Variables
         run: |
-          echo "ENV=staging" >> $GITHUB_ENV
-          echo "TF_WORKSPACE=staging" >> $GITHUB_ENV
-          echo "TF_VAR_private_key=${{ secrets.STAGING_PRIVATE_KEY }}" >> $GITHUB_ENV
-          echo "TF_VAR_did=did:web:staging.indexer.storacha.network" >> $GITHUB_ENV
+          echo "ENV=${{ inputs.env }}" >> $GITHUB_ENV
+          echo "TF_WORKSPACE=${{ inputs.workspace }}" >> $GITHUB_ENV
+          echo "TF_VAR_private_key=${{ secrets.private-key }}" >> $GITHUB_ENV
+          echo "TF_VAR_did=${{ inputs.did }}" >> $GITHUB_ENV
 
       - name: Tofu Init
         run: |
@@ -64,25 +67,11 @@ jobs:
           make lambdas
 
       - name: Terraform Plan
-        if: github.event_name == 'pull_request'
+        if: ${{ !inputs.apply }}
         run: |
           tofu -chdir="deploy/app" plan
 
       - name: Terraform Apply
-        if: github.event_name != 'pull_request'
-        run: |
-          tofu -chdir="deploy/app" apply -input=false --auto-approve
-
-      # deploy to prod on new releases
-      - name: Set Production Environment Variables
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
-        run: |
-          echo "ENV=production" >> $GITHUB_ENV
-          echo "TF_WORKSPACE=prod" >> $GITHUB_ENV
-          echo "TF_VAR_private_key=${{ secrets.PROD_PRIVATE_KEY }}" >> $GITHUB_ENV
-          echo "TF_VAR_did=did:web:indexer.storacha.network" >> $GITHUB_ENV
-
-      - name: Deploy to prod
-        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ inputs.apply }}
         run: |
           tofu -chdir="deploy/app" apply -input=false --auto-approve

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Table of Contents
 
-* [Overview](#overview)
-* [Installation](#installation)
-* [Deployment](#deployment)
-* [Contribute](#contribute)
-* [License](#license)
+- [Overview](#overview)
+- [Installation](#installation)
+- [Deployment](#deployment)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Overview
 
@@ -33,6 +33,14 @@ First, install OpenTofu e.g.
 ```sh
 brew install opentofu
 ```
+
+### AWS settings
+
+The terraform configuration will fetch AWS settings (such as credentials and the region to deploy resources to) from your local AWS configuration. Although an installation of the AWS CLI is not strictly required, it can be a convenient way to manage these settings.
+
+OpenTofu will go to the same places as the AWS CLI to find settings, which means it will read environment variables such as `AWS_REGION` and `AWS_PROFILE` and the `~/.aws/config` and `~/.aws/credentials` files.
+
+Make sure you are using the correct AWS profile and region before invoking `make` targets.
 
 ### `.env`
 

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -144,10 +144,10 @@ data "aws_iam_policy_document" "lambda_elasticache_connect_document" {
     ]
 
     resources = [
-      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["providers"].id}",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["indexes"].id}",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["claims"].id}",
-      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:user:${aws_elasticache_user.cache_iam_user.user_id}"
+      "${aws_elasticache_serverless_cache.cache["providers"].arn}",
+      "${aws_elasticache_serverless_cache.cache["indexes"].arn}",
+      "${aws_elasticache_serverless_cache.cache["claims"].arn}",
+      "${aws_elasticache_user.cache_iam_user.arn}"
     ]
   }
 }

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -34,6 +34,13 @@ data "archive_file" "function_archive" {
 }
 
 # Define functions
+data "aws_region" "legacy_claims" {
+  provider = aws.legacy_claims
+}
+
+data "aws_region" "block_index" {
+  provider = aws.block_index
+}
 
 resource "aws_lambda_function" "lambda" {
   depends_on = [ aws_cloudwatch_log_group.lambda_log_group ]
@@ -73,8 +80,10 @@ resource "aws_lambda_function" "lambda" {
         IPNI_STORE_BUCKET_REGIONAL_DOMAIN = aws_s3_bucket.ipni_store_bucket.bucket_regional_domain_name
         CLAIM_STORE_BUCKET_NAME = aws_s3_bucket.claim_store_bucket.bucket
         LEGACY_CLAIMS_TABLE_NAME = data.aws_dynamodb_table.legacy_claims_table.id
+        LEGACY_CLAIMS_TABLE_REGION = data.aws_region.legacy_claims.name
         LEGACY_CLAIMS_BUCKET_NAME = data.aws_s3_bucket.legacy_claims_bucket.id
         LEGACY_BLOCK_INDEX_TABLE_NAME = data.aws_dynamodb_table.legacy_block_index_table.id
+        LEGACY_BLOCK_INDEX_TABLE_REGION = data.aws_region.block_index.name
         LEGACY_DATA_BUCKET_URL = "https://carpark-${terraform.workspace == "prod" ? "prod" : "staging"}-0.r2.w3s.link"
         GOLOG_LOG_LEVEL = terraform.workspace == "prod" ? "error" : "debug"
     }

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -144,10 +144,10 @@ data "aws_iam_policy_document" "lambda_elasticache_connect_document" {
     ]
 
     resources = [
-      "arn:aws:elasticache:${var.region}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["providers"].id}",
-      "arn:aws:elasticache:${var.region}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["indexes"].id}",
-      "arn:aws:elasticache:${var.region}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["claims"].id}",
-      "arn:aws:elasticache:${var.region}:${var.allowed_account_ids[0]}:user:${aws_elasticache_user.cache_iam_user.user_id}"
+      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["providers"].id}",
+      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["indexes"].id}",
+      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:serverlesscache:${aws_elasticache_serverless_cache.cache["claims"].id}",
+      "arn:aws:elasticache:${data.aws_region.current.name}:${var.allowed_account_ids[0]}:user:${aws_elasticache_user.cache_iam_user.user_id}"
     ]
   }
 }

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -4,6 +4,12 @@ variable "legacy_claims_table_name" {
   default = ""
 }
 
+variable "legacy_claims_table_region" {
+  description = "The region where the legacy content-claims DynamoDB table is provisioned"
+  type = string
+  default = ""
+}
+
 variable "legacy_claims_bucket_name" {
   description = "The name of the S3 bucket used by the legacy content-claims service"
   type = string
@@ -16,6 +22,7 @@ variable "legacy_block_index_table_name" {
   default = ""
 }
 
+# the block index table is always deployed in us-west-2 for both prod and staging
 variable "legacy_block_index_table_region" {
   description = "The region where the legacy block index DynamoDB table is provisioned"
   type = string
@@ -24,6 +31,7 @@ variable "legacy_block_index_table_region" {
 
 locals {
     inferred_legacy_claims_table_name = var.legacy_claims_table_name != "" ? var.legacy_claims_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-content-claims-claims-v1"
+    inferred_legacy_claims_table_region = var.legacy_claims_table_region != "" ? var.legacy_claims_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
     inferred_legacy_claims_bucket_name = var.legacy_claims_bucket_name != "" ? var.legacy_claims_bucket_name : "${terraform.workspace == "prod" ? "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8" : "staging-content-claims-buc-claimsv1bucketefd46802-1xx2brszve6t3"}"
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
 }
@@ -32,11 +40,16 @@ data "aws_s3_bucket" "legacy_claims_bucket" {
   bucket = local.inferred_legacy_claims_bucket_name
 }
 
+provider "aws" {
+  alias = "legacy_claims"
+  region = local.inferred_legacy_claims_table_region
+}
+
 data "aws_dynamodb_table" "legacy_claims_table" {
+  provider = aws.legacy_claims
   name = local.inferred_legacy_claims_table_name
 }
 
-# the block index table is always deployed in us-west-2 for both prod and staging
 provider "aws" {
   alias = "block_index"
   region = var.legacy_block_index_table_region

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -1,13 +1,13 @@
 variable "legacy_claims_table_name" {
   description = "The name of the DynamoDB table used by the legacy content-claims service"
   type = string
-  default = "prod-content-claims-claims-v1"
+  default = ""
 }
 
 variable "legacy_claims_bucket_name" {
   description = "The name of the S3 bucket used by the legacy content-claims service"
   type = string
-  default = "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8"
+  default = ""
 }
 
 variable "legacy_block_index_table_name" {
@@ -23,15 +23,17 @@ variable "legacy_block_index_table_region" {
 }
 
 locals {
+    inferred_legacy_claims_table_name = var.legacy_claims_table_name != "" ? var.legacy_claims_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-content-claims-claims-v1"
+    inferred_legacy_claims_bucket_name = var.legacy_claims_bucket_name != "" ? var.legacy_claims_bucket_name : "${terraform.workspace == "prod" ? "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8" : "staging-content-claims-buc-claimsv1bucketefd46802-1xx2brszve6t3"}"
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
 }
 
 data "aws_s3_bucket" "legacy_claims_bucket" {
-  bucket = var.legacy_claims_bucket_name
+  bucket = local.inferred_legacy_claims_bucket_name
 }
 
 data "aws_dynamodb_table" "legacy_claims_table" {
-  name = var.legacy_claims_table_name
+  name = local.inferred_legacy_claims_table_name
 }
 
 # the block index table is always deployed in us-west-2 for both prod and staging

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -16,6 +16,12 @@ variable "legacy_block_index_table_name" {
   default = ""
 }
 
+variable "legacy_block_index_table_region" {
+  description = "The region where the legacy block index DynamoDB table is provisioned"
+  type = string
+  default = "us-west-2"
+}
+
 locals {
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
 }
@@ -28,7 +34,14 @@ data "aws_dynamodb_table" "legacy_claims_table" {
   name = var.legacy_claims_table_name
 }
 
+# the block index table is always deployed in us-west-2 for both prod and staging
+provider "aws" {
+  alias = "block_index"
+  region = var.legacy_block_index_table_region
+}
+
 data "aws_dynamodb_table" "legacy_block_index_table" {
+  provider = aws.block_index
   name = local.inferred_legacy_block_index_table_name
 }
 

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -31,8 +31,3 @@ provider "aws" {
 }
 
 data "aws_region" "current" {}
-
-provider "aws" {
-  alias = "virginia"
-  region = "us-east-1"
-}

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -16,7 +16,6 @@ terraform {
 }
 
 provider "aws" {
-  region              = var.region
   allowed_account_ids = var.allowed_account_ids
   default_tags {
     
@@ -30,6 +29,8 @@ provider "aws" {
     }
   }
 }
+
+data "aws_region" "current" {}
 
 provider "aws" {
   alias = "virginia"

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -29,5 +29,3 @@ provider "aws" {
     }
   }
 }
-
-data "aws_region" "current" {}

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -4,12 +4,6 @@ variable "app" {
   default = "indexer"
 }
 
-variable "region" {
-  description = "aws region for all services"
-  type = string
-  default = "us-west-2"
-}
-
 variable "allowed_account_ids" {
   description = "account ids used for AWS"
   type = list(string)

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -13,7 +13,6 @@ terraform {
 }
 
 provider "aws" {
-  region              = var.region
   allowed_account_ids = var.allowed_account_ids
   default_tags {
     

--- a/deploy/shared/variables.tf
+++ b/deploy/shared/variables.tf
@@ -4,12 +4,6 @@ variable "app" {
   default = "indexer"
 }
 
-variable "region" {
-  description = "aws region for all services"
-  type = string
-  default = "us-west-2"
-}
-
 variable "allowed_account_ids" {
   description = "account ids used for AWS"
   type = list(string)


### PR DESCRIPTION
Resolves #54 

Most of our services get staging and production environments deployed to different regions. This PR enables this separation for the `indexing-service`.

The changes also make the staging `indexing-service` use the staging `content-claims` resources, instead of always pointing to the production ones as it does right now.