### PR TITLE
fix(ci): allow terraform jobs to run concurrently when they target different workspaces

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,7 +24,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.workspace }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
When I split the terraform workflow in two different workflows to make it reusable in #83 I mistakenly used the same concurrency group for both, which prevents the child workflow from running.

This PR adds the workspace to the concurrency group key so that only workflows that target the same workspace share the same concurrency group.