### PR TITLE
chore(main): minor changes & doc enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ indexer:
 clean-indexer:
 	rm -f ./indexer
 
+.PHONY: test
+
+test:
+	go test -v ./...
+
+.PHONY: ucangen
+
 ucangen:
 	go build -o ./ucangen cmd/ucangen/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ clean-indexer:
 .PHONY: test
 
 test:
-	go test -v ./...
-
-.PHONY: ucangen
+	go test -race -v ./...
 
 ucangen:
 	go build -o ./ucangen cmd/ucangen/main.go

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ First, install OpenTofu e.g.
 brew install opentofu
 ```
 
+or for Linux distributions that support Snap:
+
+```sh
+snap install --classic opentofu
+```
+
+for other Operating Systems see: https://opentofu.org/docs/intro/install
+
 ### AWS settings
 
 The terraform configuration will fetch AWS settings (such as credentials and the region to deploy resources to) from your local AWS configuration. Although an installation of the AWS CLI is not strictly required, it can be a convenient way to manage these settings.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Overview](#overview)
 - [Installation](#installation)
 - [Deployment](#deployment)
+- [CLI](#cli)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -104,16 +105,22 @@ This will plan a deployment, but not execute it -- useful to see ahead what chan
 
 The big kahuna! This will deploy all of your changes, including redeploying lambdas if any of code changes.
 
-## Query
+## CLI
 
-#### `./indexer query <CID>`
-Attempts to find the given CID in the Indexer node. The result is a Location Claim that needs to be used to fetch the actual content associated with that CID. In case you want to query a specific node, you can use the following command:
+The command line interface can be used to query an indexer node. You'll need to compile the binary first:
 
 ```sh
-./indexer query -u https://<NODE_NAME>.indexer.storacha.network <CID>
+make indexer
 ```
 
-If you don't specify a node it will query the Storacha Production node at https://indexer.storacha.network
+#### `./indexer query <CID>`
+Attempts to find the given CID in the Indexer node. The result can be multiple Location Claims, as there may be several storage nodes that store copies of the content, as well as potential indexes and the indexes themselves. If you want to query a specific node, you can use the following command:
+
+```sh
+./indexer query -u https://<INDEXING_SERVICE_URL> <CID>
+```
+
+If you don't specify a node it will query the Storacha Production node at https://indexer.storacha.network .
 
 ## Releasing a new version
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ This will simply compile the lambdas locally and put then in the `build` directo
 
 You should only need to run this once -- initializes your terraform deployment and workspace. Make sure you've set `TF_WORKSPACE` first!
 
+If the `make init` fails you will need to execute `tofu init` directly from the `deploy/app` folder to install the required dependencies, and it will update the `.terraform.lock.hcl` file if needed.
+
 #### `make validate`
 
 This will validate your terraform configuration -- good to run to check errors in any changes you make to terraform configs.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ This will plan a deployment, but not execute it -- useful to see ahead what chan
 
 The big kahuna! This will deploy all of your changes, including redeploying lambdas if any of code changes.
 
+## Query
+
+#### `./indexer query <CID>`
+Attempts to find the given CID in the Indexer node. The result is a Location Claim that needs to be used to fetch the actual content associated with that CID. In case you want to query a specific node, you can use the following command:
+
+```sh
+./indexer query -u https://<NODE_NAME>.indexer.storacha.network <CID>
+```
+
+If you don't specify a node it will query the Storacha Production node at https://indexer.storacha.network
+
 ## Releasing a new version
 
 Every time changes are merged to `main` the staging environment is automatically updated. Therefore, staging always runs the latest version of the code. The production environment, however, is only updated when a new version is released.

--- a/deploy/app/.terraform.lock.hcl
+++ b/deploy/app/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.opentofu.org/hashicorp/archive" {
   version = "2.6.0"
   hashes = [
+    "h1:5SUnSjTxv00v7kZJIdX0KXEBUqtiDVkupcLMEQnb8Qw=",
     "h1:s1OObC0b95ceQkrAMqL4q6wMYDBWYt8swZbLup+UJXI=",
     "zh:046b3ba4223002d1cd1c917e8c21b58a636fcd751073745e3db99beebe254dd8",
     "zh:1c1ed2ea0927b491689c3c7d178880cd9902f2a5339da8f46c56279920329a27",
@@ -23,6 +24,7 @@ provider "registry.opentofu.org/hashicorp/aws" {
   constraints = ">= 5.73.0"
   hashes = [
     "h1:o72+gIuszJDr7rRFBKA7vtD7oiJhn7E5SJZZOMjLtWY=",
+    "h1:sWp8yBIAzMr2RrcSucpHJ0oauXGJgfZ0EZpVIMEMxDc=",
     "zh:2b0d6e17d79ee1d59157e72d1019dfed49e047b376975a757adedb78d4794750",
     "zh:30878bdf37b2706780d07b67b13aff746132c78313866add862c2f1877beb2fd",
     "zh:46a5dac7bb99721940d979f1444e55e318d531392728d9922e0e72c1147cc8d6",


### PR DESCRIPTION
### Changes
- Added `test` target to the Makefile.
- Additional information about `Opentofu` installation for different distros.
- Updated `.terraform.lock.hcl` dependencies due to Linux installation.
- Updated `README.md` about potential failure in the `make init` command.
- Added basic Indexer query command example.