### PR TITLE
test(claim-cache): add unit tests for Claim Cache functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,8 @@ plan: deploy/app/.terraform .tfworkspace $(LAMBDAS)
 
 apply: deploy/app/.terraform .tfworkspace $(LAMBDAS)
 	tofu -chdir=deploy/app apply
+
+.PHONY: mockery
+
+mockery:
+	@InterfaceDir="pkg/internal/testutil/extmocks" mockery --config=.mockery.yaml

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -332,6 +332,10 @@ func NewIndexingService(blobIndexLookup blobindexlookup.BlobIndexLookup, claims 
 
 func Cache(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
 	caps := claim.Capabilities()
+	if len(caps) == 0 {
+		return fmt.Errorf("missing capabilities in claim: %s", claim.Link())
+	}
+
 	switch caps[0].Can() {
 	case assert.LocationAbility:
 		return cacheLocationCommitment(ctx, claims, provIndex, provider, claim)
@@ -342,10 +346,6 @@ func Cache(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, claim
 
 func cacheLocationCommitment(ctx context.Context, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
 	caps := claim.Capabilities()
-	if len(caps) == 0 {
-		return fmt.Errorf("missing capabilities in claim: %s", claim.Link())
-	}
-
 	if caps[0].Can() != assert.LocationAbility {
 		return fmt.Errorf("unsupported claim: %s", caps[0].Can())
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -437,10 +437,46 @@ func TestCacheClaim(t *testing.T) {
 		}
 		ctx := context.Background()
 
+		locationClaim := assert.Location.New(testutil.Service.DID().String(), assert.LocationCaveats{
+			Content:  testutil.Must(assert.Digest(adm.DigestModel{Digest: []byte{1, 2, 3}}))(t),
+			Location: []url.URL{*testutil.Must(url.Parse("https://storacha.network"))(t)},
+		})
+		locationDelegation := testutil.Must(delegation.Delegate(
+			testutil.Service,
+			testutil.Alice,
+			[]ucan.Capability[assert.LocationCaveats]{locationClaim},
+			// set the expiration to 1 hour in the future
+			delegation.WithExpiration(int(time.Now().Add(time.Hour).Unix())),
+		))(t)
+
+		anyContextID := mock.AnythingOfType("string")
+		anyMultihash := mock.AnythingOfType("iter.Seq[github.com/multiformats/go-multihash.Multihash]")
+		anyMetadata := mock.AnythingOfType("metadata.Metadata")
+		mockProviderIndex.EXPECT().Cache(ctx, *providerAddr, anyContextID, anyMultihash, anyMetadata).Return(nil)
+		mockClaimsService.EXPECT().Cache(ctx, locationDelegation).Return(nil)
+
+		// Cache the claim with expiration
+		err := Cache(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, locationDelegation)
+		require.NoError(t, err)
+	})
+
+	t.Run("handle a delegation with a range in the caveats and cache the claim", func(t *testing.T) {
+		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
+		mockProviderIndex := providerindex.NewMockProviderIndex(t)
+		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
+		providerAddr := &peer.AddrInfo{
+			Addrs: []ma.Multiaddr{
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fclaims%2F%7Bclaim%7D"))(t),
+			},
+		}
+		ctx := context.Background()
+
 		// Create a claim with a context ID that will fail to encode
 		locationClaim := assert.Location.New(testutil.Service.DID().String(), assert.LocationCaveats{
 			Content:  testutil.Must(assert.Digest(adm.DigestModel{Digest: []byte{1, 2, 3}}))(t),
 			Location: []url.URL{*testutil.Must(url.Parse("https://storacha.network"))(t)},
+			// set the range
+			Range: &assert.Range{Offset: 0, Length: &[]uint64{3}[0]},
 		})
 		locationDelegation := testutil.Must(delegation.Delegate(
 			testutil.Service,

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -495,6 +495,36 @@ func TestCacheClaim(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("handle the error from the claims.Cache function call", func(t *testing.T) {
+		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
+		mockProviderIndex := providerindex.NewMockProviderIndex(t)
+		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
+		providerAddr := &peer.AddrInfo{
+			Addrs: []ma.Multiaddr{
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fclaims%2F%7Bclaim%7D"))(t),
+			},
+		}
+		ctx := context.Background()
+
+		locationClaim := assert.Location.New(testutil.Service.DID().String(), assert.LocationCaveats{
+			Content:  testutil.Must(assert.Digest(adm.DigestModel{Digest: []byte{1, 2, 3}}))(t),
+			Location: []url.URL{*testutil.Must(url.Parse("https://storacha.network"))(t)},
+		})
+		locationDelegation := testutil.Must(delegation.Delegate(
+			testutil.Service,
+			testutil.Alice,
+			[]ucan.Capability[assert.LocationCaveats]{locationClaim},
+		))(t)
+
+		// mock the error from the claims.Cache function call
+		mockClaimsService.EXPECT().Cache(ctx, locationDelegation).Return(errors.New("something went wrong while caching claim in claims.Cache"))
+
+		// Attempt to cache the claim
+		err := Cache(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, locationDelegation)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "something went wrong while caching claim in claims.Cache")
+	})
+
 }
 
 func TestUrlForResource(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -471,7 +471,6 @@ func TestCacheClaim(t *testing.T) {
 		}
 		ctx := context.Background()
 
-		// Create a claim with a context ID that will fail to encode
 		locationClaim := assert.Location.New(testutil.Service.DID().String(), assert.LocationCaveats{
 			Content:  testutil.Must(assert.Digest(adm.DigestModel{Digest: []byte{1, 2, 3}}))(t),
 			Location: []url.URL{*testutil.Must(url.Parse("https://storacha.network"))(t)},
@@ -495,6 +494,7 @@ func TestCacheClaim(t *testing.T) {
 		err := Cache(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, locationDelegation)
 		require.NoError(t, err)
 	})
+
 }
 
 func TestUrlForResource(t *testing.T) {


### PR DESCRIPTION
### Test Cases
- [x] should cache `assert/location` claims
- [x] should return an error indicating missing capabilities
- [x] should return an error indicating a failure in reading caveats
- [x] should handle the expiration correctly and cache the claim
- [x] should handle the absence of expiration correctly and cache the claim
- [x] should handle a delegation with a range in the caveats and cache the claim
- [x] should handle a delegation without a range in the caveats and cache the claim
- [x] should propagate the error from the `claims.Cache` function
- [x] should propagate the error from the `providerIndex.Cache` function

### Minor Changes
- Added the Mockery target to the Makefile

resolves https://github.com/storacha/project-tracking/issues/170