### PR TITLE
test(publish-index-claim): add unit tests for Publish Index Claim functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean-indexer:
 .PHONY: test
 
 test:
-	go test -race -v ./...
+	go clean -testcache && go test -race -v ./...
 
 ucangen:
 	go build -o ./ucangen cmd/ucangen/main.go

--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,4 @@ apply: deploy/app/.terraform .tfworkspace $(LAMBDAS)
 .PHONY: mockery
 
 mockery:
-	@InterfaceDir="pkg/internal/testutil/extmocks" mockery --config=.mockery.yaml
+	mockery --config=.mockery.yaml

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -345,12 +345,12 @@ func Cache(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, claim
 }
 
 func cacheLocationCommitment(ctx context.Context, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
-	caps := claim.Capabilities()
-	if caps[0].Can() != assert.LocationAbility {
-		return fmt.Errorf("unsupported claim: %s", caps[0].Can())
+	capability := claim.Capabilities()[0]
+	if capability.Can() != assert.LocationAbility {
+		return fmt.Errorf("unsupported claim: %s", capability.Can())
 	}
 
-	nb, rerr := assert.LocationCaveatsReader.Read(caps[0].Nb())
+	nb, rerr := assert.LocationCaveatsReader.Read(capability.Nb())
 	if rerr != nil {
 		return fmt.Errorf("reading index claim data: %w", rerr)
 	}
@@ -394,6 +394,9 @@ func cacheLocationCommitment(ctx context.Context, claims contentclaims.Service, 
 
 func Publish(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
 	caps := claim.Capabilities()
+	if len(caps) == 0 {
+		return fmt.Errorf("missing capabilities in claim: %s", claim.Link())
+	}
 	switch caps[0].Can() {
 	case assert.EqualsAbility:
 		return publishEqualsClaim(ctx, claims, provIndex, provider, claim)
@@ -405,16 +408,12 @@ func Publish(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, cla
 }
 
 func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
-	caps := claim.Capabilities()
-	if len(caps) == 0 {
-		return fmt.Errorf("missing capabilities in claim: %s", claim.Link())
+	capability := claim.Capabilities()[0]
+	if capability.Can() != assert.EqualsAbility {
+		return fmt.Errorf("unsupported claim: %s", capability.Can())
 	}
 
-	if caps[0].Can() != assert.EqualsAbility {
-		return fmt.Errorf("unsupported claim: %s", caps[0].Can())
-	}
-
-	nb, rerr := assert.EqualsCaveatsReader.Read(caps[0].Nb())
+	nb, rerr := assert.EqualsCaveatsReader.Read(capability.Nb())
 	if rerr != nil {
 		return fmt.Errorf("reading index claim data: %w", rerr)
 	}
@@ -450,16 +449,12 @@ func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provI
 }
 
 func publishIndexClaim(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
-	caps := claim.Capabilities()
-	if len(caps) == 0 {
-		return fmt.Errorf("missing capabilities in claim: %s", claim.Link())
+	capability := claim.Capabilities()[0]
+	if capability.Can() != assert.IndexAbility {
+		return fmt.Errorf("unsupported claim: %s", capability.Can())
 	}
 
-	if caps[0].Can() != assert.IndexAbility {
-		return fmt.Errorf("unsupported claim: %s", caps[0].Can())
-	}
-
-	nb, rerr := assert.IndexCaveatsReader.Read(caps[0].Nb())
+	nb, rerr := assert.IndexCaveatsReader.Read(capability.Nb())
 	if rerr != nil {
 		return fmt.Errorf("reading index claim data: %w", rerr)
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -572,7 +572,7 @@ func fetchBlobIndex(ctx context.Context, blobIndex blobindexlookup.BlobIndexLook
 
 	wg.Wait()
 	if validateErr != nil {
-		return nil, fmt.Errorf("verifying claim: %w", err)
+		return nil, fmt.Errorf("verifying claim: %w", validateErr)
 	}
 
 	return idx, nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -568,15 +568,46 @@ func TestPublishIndexClaim(t *testing.T) {
 			TargetClaims: []multicodec.Code{metadata.LocationCommitmentID},
 		}).Return([]model.ProviderResult{{}}, nil)
 
-		// Simulate an error when fetching the blob index
-		// mockBlobIndexLookup.EXPECT().Find(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("failed to fetch blob index"))
-
 		// Attempt to publish the claim
 		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
 
 		// Expect an error indicating a problem with fetching the blob index
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "fetching blob index: decoding location commitment metadata")
+	})
+
+	t.Run("error when fetching the blob index fails with invalid metadata type", func(t *testing.T) {
+		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
+		mockProviderIndex := providerindex.NewMockProviderIndex(t)
+		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
+		contentLink := testutil.RandomCID()
+
+		ctx := context.Background()
+
+		providerAddr := &peer.AddrInfo{
+			Addrs: []ma.Multiaddr{
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fclaims%2F%7Bclaim%7D"))(t),
+			},
+		}
+
+		// Create a valid index claim
+		_, indexDelegation, indexResult, indexLink, _ := buildTestIndexClaim(t, contentLink.(cidlink.Link), providerAddr)
+
+		// Simulate caching the claim in claims.Publish
+		mockClaimsService.EXPECT().Publish(ctx, indexDelegation).Return(nil)
+
+		// Simulate a successful result from provIndex.Find
+		mockProviderIndex.EXPECT().Find(ctx, providerindex.QueryKey{
+			Hash:         indexLink.Hash(),
+			TargetClaims: []multicodec.Code{metadata.LocationCommitmentID},
+		}).Return([]model.ProviderResult{indexResult}, nil) // this is the wrong claim type
+
+		// Attempt to publish the claim
+		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
+
+		// Expect an error indicating a problem with the metadata type
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fetching blob index: metadata is not expected type")
 	})
 
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -285,8 +285,9 @@ func buildTestIndexClaim(t *testing.T, contentLink cidlink.Link, providerAddr *p
 	}.Sum(testutil.Must(io.ReadAll(delegation.Archive(indexDelegation)))(t)))(t)
 
 	indexMetadata := metadata.IndexClaimMetadata{
-		Index: indexLink.Cid,
-		Claim: indexDelegationCid,
+		Index:      indexLink.Cid,
+		Claim:      indexDelegationCid,
+		Expiration: time.Now().Add(time.Hour).Unix(),
 	}
 
 	indexResult := model.ProviderResult{
@@ -721,6 +722,49 @@ func TestPublishIndexClaim(t *testing.T) {
 		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "fetching blob index: verifying claim: failed to find claim")
+	})
+
+	t.Run("error when publishing the claim", func(t *testing.T) {
+		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
+		mockProviderIndex := providerindex.NewMockProviderIndex(t)
+		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
+		contentLink := testutil.RandomCID()
+
+		ctx := context.Background()
+
+		providerAddr := &peer.AddrInfo{
+			Addrs: []ma.Multiaddr{
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fclaims%2F%7Bclaim%7D"))(t),
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fblobs%2F%7Bblob%7D"))(t),
+			},
+		}
+
+		// content will have a location claim, an index claim
+		_, locationDelegation, locationResult := buildTestLocationClaim(t, contentLink.(cidlink.Link), providerAddr)
+		_, indexDelegation, _, indexLink, shardIndex := buildTestIndexClaim(t, contentLink.(cidlink.Link), providerAddr)
+
+		// Simulate caching the claim in claims.Publish
+		mockClaimsService.EXPECT().Publish(ctx, indexDelegation).Return(nil)
+
+		// Simulate a successful result from provIndex.Find
+		mockProviderIndex.EXPECT().Find(ctx, providerindex.QueryKey{
+			Hash:         indexLink.Hash(),
+			TargetClaims: []multicodec.Code{metadata.LocationCommitmentID},
+		}).Return([]model.ProviderResult{locationResult}, nil)
+
+		// Simulate a successful result from blobIndexLookup.Find
+		mockBlobIndexLookup.EXPECT().Find(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(shardIndex, nil)
+
+		// Simulate a failure from claims.Find
+		mockClaimsService.EXPECT().Find(ctx, mock.Anything, mock.Anything).Return(locationDelegation, nil)
+
+		// Simulate a failure from provIndex.Publish
+		mockProviderIndex.EXPECT().Publish(ctx, *providerAddr, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("failed to publish claim"))
+
+		// Attempt to publish the claim
+		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "publishing claim: failed to publish claim")
 	})
 
 	t.Run("error when publishing the claim", func(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -409,7 +409,7 @@ func TestPublishIndexClaim(t *testing.T) {
 		claim, err := delegation.Delegate(
 			testutil.Alice,
 			testutil.Bob,
-			[]ucan.Capability[ok.Unit]{}, // No capabilities
+			[]ucan.Capability[ucan.NoCaveats]{},
 		)
 		require.NoError(t, err)
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -542,6 +542,43 @@ func TestPublishIndexClaim(t *testing.T) {
 		require.Contains(t, err.Error(), "finding location commitment: failed to find location commitments")
 	})
 
+	t.Run("error when fetching the blob index fails to decode location commitment metadata", func(t *testing.T) {
+		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
+		mockProviderIndex := providerindex.NewMockProviderIndex(t)
+		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
+		contentLink := testutil.RandomCID()
+
+		ctx := context.Background()
+
+		providerAddr := &peer.AddrInfo{
+			Addrs: []ma.Multiaddr{
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fclaims%2F%7Bclaim%7D"))(t),
+			},
+		}
+
+		// Create a valid index claim
+		_, indexDelegation, _, indexLink, _ := buildTestIndexClaim(t, contentLink.(cidlink.Link), providerAddr)
+
+		// Simulate caching the claim in claims.Publish
+		mockClaimsService.EXPECT().Publish(ctx, indexDelegation).Return(nil)
+
+		// Simulate a successful result from provIndex.Find
+		mockProviderIndex.EXPECT().Find(ctx, providerindex.QueryKey{
+			Hash:         indexLink.Hash(),
+			TargetClaims: []multicodec.Code{metadata.LocationCommitmentID},
+		}).Return([]model.ProviderResult{{}}, nil)
+
+		// Simulate an error when fetching the blob index
+		// mockBlobIndexLookup.EXPECT().Find(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("failed to fetch blob index"))
+
+		// Attempt to publish the claim
+		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
+
+		// Expect an error indicating a problem with fetching the blob index
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fetching blob index: decoding location commitment metadata")
+	})
+
 }
 
 func TestCacheClaim(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -683,7 +683,7 @@ func TestPublishIndexClaim(t *testing.T) {
 		require.Contains(t, err.Error(), "fetching blob index: verifying claim: building claim URL: no {claim} endpoint found")
 	})
 
-	t.Run("error when fetching the blob index fails to find the claim", func(t *testing.T) {
+	t.Run("error when fetching the blob index fails to find the location commitment claim", func(t *testing.T) {
 		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
 		mockProviderIndex := providerindex.NewMockProviderIndex(t)
 		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
@@ -721,6 +721,49 @@ func TestPublishIndexClaim(t *testing.T) {
 		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "fetching blob index: verifying claim: failed to find claim")
+	})
+
+	t.Run("error when publishing the claim", func(t *testing.T) {
+		mockClaimsService := contentclaims.NewMockContentClaimsService(t)
+		mockProviderIndex := providerindex.NewMockProviderIndex(t)
+		mockBlobIndexLookup := blobindexlookup.NewMockBlobIndexLookup(t)
+		contentLink := testutil.RandomCID()
+
+		ctx := context.Background()
+
+		providerAddr := &peer.AddrInfo{
+			Addrs: []ma.Multiaddr{
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fclaims%2F%7Bclaim%7D"))(t),
+				testutil.Must(ma.NewMultiaddr("/dns/storacha.network/tls/http/http-path/%2Fblobs%2F%7Bblob%7D"))(t),
+			},
+		}
+
+		// content will have a location claim, an index claim
+		_, locationDelegation, locationResult := buildTestLocationClaim(t, contentLink.(cidlink.Link), providerAddr)
+		_, indexDelegation, _, indexLink, shardIndex := buildTestIndexClaim(t, contentLink.(cidlink.Link), providerAddr)
+
+		// Simulate caching the claim in claims.Publish
+		mockClaimsService.EXPECT().Publish(ctx, indexDelegation).Return(nil)
+
+		// Simulate a successful result from provIndex.Find
+		mockProviderIndex.EXPECT().Find(ctx, providerindex.QueryKey{
+			Hash:         indexLink.Hash(),
+			TargetClaims: []multicodec.Code{metadata.LocationCommitmentID},
+		}).Return([]model.ProviderResult{locationResult}, nil)
+
+		// Simulate a successful result from blobIndexLookup.Find
+		mockBlobIndexLookup.EXPECT().Find(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(shardIndex, nil)
+
+		// Simulate a failure from claims.Find
+		mockClaimsService.EXPECT().Find(ctx, mock.Anything, mock.Anything).Return(locationDelegation, nil)
+
+		// Simulate a failure from provIndex.Publish
+		mockProviderIndex.EXPECT().Publish(ctx, *providerAddr, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("failed to publish claim"))
+
+		// Attempt to publish the claim
+		err := Publish(ctx, mockBlobIndexLookup, mockClaimsService, mockProviderIndex, *providerAddr, indexDelegation)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "publishing claim: failed to publish claim")
 	})
 
 }


### PR DESCRIPTION
### Test Cases
- [x] Successfully publish the claim without errors
- [x] Return an error indicating missing capabilities
- [x] Return an error indicating an unsupported ability type
- [x] Return an error related to reading index claim caveats
- [x] Return an error related to caching the claim in `claims.Publish`
- [x] Return an error indicating no location commitments found in `provIndex.Find`
- [x] Return an error indicating `provIndex.Find` failed
- [x] Return an error when fetching the blob index fails to decode location commitment metadata
- [x] Return an error when fetching the blob index fails with invalid metadata type
- [x] Return an error when fetching the blob index fails to build the retrieval URL
- [x] Return an error when fetching the blob index fails to build the claim URL
- [x] Return an error when fetching the blob index fails to find the location commitment claim
- [x] Handle the expiration correctly and publish the claim
- [x] Return an error related to publishing the claim

### Minor Changes
- Clean test cache before running tests via `make test`
- Removed invalid mockery config

resolves: https://github.com/storacha/project-tracking/issues/168