### PR TITLE
chore(publish-equals-claim): add unit tests for Publish Equals Claim functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ clean-indexer:
 .PHONY: test
 
 test:
-	go clean -testcache && go test -race -v ./...
+	go test -race -v ./...
+
+.PHONY: test-nocache
+
+test-nocache:
+	go clean -testcache && make test
 
 ucangen:
 	go build -o ./ucangen cmd/ucangen/main.go

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/mock_*.go"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -409,13 +409,9 @@ func Publish(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, cla
 
 func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
 	capability := claim.Capabilities()[0]
-	if capability.Can() != assert.EqualsAbility {
-		return fmt.Errorf("unsupported claim: %s", capability.Can())
-	}
-
 	nb, rerr := assert.EqualsCaveatsReader.Read(capability.Nb())
 	if rerr != nil {
-		return fmt.Errorf("reading index claim data: %w", rerr)
+		return fmt.Errorf("reading equals claim data: %w", rerr)
 	}
 
 	err := claims.Publish(ctx, claim)
@@ -450,10 +446,6 @@ func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provI
 
 func publishIndexClaim(ctx context.Context, blobIndex blobindexlookup.BlobIndexLookup, claims contentclaims.Service, provIndex providerindex.ProviderIndex, provider peer.AddrInfo, claim delegation.Delegation) error {
 	capability := claim.Capabilities()[0]
-	if capability.Can() != assert.IndexAbility {
-		return fmt.Errorf("unsupported claim: %s", capability.Can())
-	}
-
 	nb, rerr := assert.IndexCaveatsReader.Read(capability.Nb())
 	if rerr != nil {
 		return fmt.Errorf("reading index claim data: %w", rerr)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -416,7 +416,7 @@ func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provI
 
 	err := claims.Publish(ctx, claim)
 	if err != nil {
-		return fmt.Errorf("caching claim with claim service: %w", err)
+		return fmt.Errorf("caching equals claim with claim service: %w", err)
 	}
 
 	var exp int
@@ -438,7 +438,7 @@ func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provI
 	contextID := nb.Equals.Binary()
 	err = provIndex.Publish(ctx, provider, contextID, slices.Values(digests), meta)
 	if err != nil {
-		return fmt.Errorf("publishing claim: %w", err)
+		return fmt.Errorf("publishing equals claim: %w", err)
 	}
 
 	return nil
@@ -453,7 +453,7 @@ func publishIndexClaim(ctx context.Context, blobIndex blobindexlookup.BlobIndexL
 
 	err := claims.Publish(ctx, claim)
 	if err != nil {
-		return fmt.Errorf("caching claim with claim lookup: %w", err)
+		return fmt.Errorf("caching index claim with claim lookup: %w", err)
 	}
 
 	results, err := provIndex.Find(ctx, providerindex.QueryKey{
@@ -503,7 +503,7 @@ func publishIndexClaim(ctx context.Context, blobIndex blobindexlookup.BlobIndexL
 	contextID := nb.Index.Binary()
 	err = provIndex.Publish(ctx, provider, contextID, digests.Keys(), meta)
 	if err != nil {
-		return fmt.Errorf("publishing claim: %w", err)
+		return fmt.Errorf("publishing index claim: %w", err)
 	}
 
 	return nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -315,8 +315,9 @@ func buildTestEqualsClaim(t *testing.T, contentLink cidlink.Link, providerAddr *
 	}.Sum(testutil.Must(io.ReadAll(delegation.Archive(equalsDelegation)))(t)))(t)
 
 	equalsMetadata := metadata.EqualsClaimMetadata{
-		Equals: equivalentCid.(cidlink.Link).Cid,
-		Claim:  equalsDelegationCid,
+		Equals:     equivalentCid.(cidlink.Link).Cid,
+		Claim:      equalsDelegationCid,
+		Expiration: time.Now().Add(time.Hour).Unix(),
 	}
 
 	equalsProviderResults := model.ProviderResult{


### PR DESCRIPTION
### Test Cases
- [x] Successfully publishes a claim
- [x] Error when reading caveats fails
- [x] Error when publishing claim in claims service fails
- [x] Error when publishing claim in provider index fails
- [x] Correctly handles a claim with expiration

### Minor Changes
- Added a new target to the makefile to run tests without cache
- Added codecov config to ignore mock files
- Fixed some error messages

Resolves https://github.com/storacha/project-tracking/issues/169