### PR TITLE
feat: enable point in time recovery and deletion protection in prod

### DIFF
--- a/deploy/app/dynamodb.tf
+++ b/deploy/app/dynamodb.tf
@@ -18,6 +18,12 @@ resource "aws_dynamodb_table" "metadata" {
   tags = {
     Name = "${terraform.workspace}-${var.app}-metadata"
   }
+
+  point_in_time_recovery {
+    enabled = terraform.workspace == "prod"
+  }
+
+  deletion_protection_enabled = terraform.workspace == "prod"
 }
 
 resource "aws_dynamodb_table" "chunk_links" {
@@ -40,4 +46,10 @@ resource "aws_dynamodb_table" "chunk_links" {
   tags = {
     Name = "${terraform.workspace}-${var.app}-chunk-links"
   }
+
+  point_in_time_recovery {
+    enabled = terraform.workspace == "prod"
+  }
+
+  deletion_protection_enabled = terraform.workspace == "prod"
 }


### PR DESCRIPTION
Enables deletion protection for production DynamoDB tables so we don't accidentally delete them. Also enables point in time recovery...it might be possible to recreate these tables from the chain data but it will probably be better if we can just restore them.