### PR TITLE
fix(tests): flaky test in BucketFallbackMapper tests

### DIFF
--- a/pkg/aws/bucketfallbackmapper.go
+++ b/pkg/aws/bucketfallbackmapper.go
@@ -48,9 +48,13 @@ func (cfm BucketFallbackMapper) GetClaims(ctx context.Context, contentHash multi
 	}
 
 	resp, err := cfm.httpClient.Head(cfm.bucketURL.JoinPath(toBlobKey(contentHash)).String())
-	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, types.ErrKeyNotFound
 	}
+
 	size := uint64(resp.ContentLength)
 	delegation, err := cassert.Location.Delegate(
 		cfm.id,

--- a/pkg/aws/bucketfallbackmapper_test.go
+++ b/pkg/aws/bucketfallbackmapper_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
@@ -31,7 +32,13 @@ func TestBucketFallbackMapper(t *testing.T) {
 	baseMap := bytemap.NewByteMap[multihash.Multihash, cidsAndError](-1)
 	responses := bytemap.NewByteMap[multihash.Multihash, resp](-1)
 	signer := testutil.RandomSigner()
-	serverURL := testutil.Must(url.Parse("http://localhost:8888"))(t)
+
+	// set up test server
+	mux := http.NewServeMux()
+	mux.Handle("/{multihash1}/{multihash2}", mockServer{responses})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	serverURL := testutil.Must(url.Parse(server.URL))(t)
 
 	hasBaseResultsHash := testutil.RandomMultihash()
 	hasBaseResultCids := []cid.Cid{testutil.RandomCID().(cidlink.Link).Cid}
@@ -104,17 +111,6 @@ func TestBucketFallbackMapper(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			doneErr := make(chan error, 1)
-			mux := http.NewServeMux()
-			mux.Handle("/{multihash1}/{multihash2}", mockServer{responses})
-			server := &http.Server{
-				Addr:    serverURL.Host,
-				Handler: mux,
-			}
-			go func() {
-				doneErr <- server.ListenAndServe()
-			}()
-
 			bucketFallbackMapper := aws.NewBucketFallbackMapper(signer, http.DefaultClient, serverURL, mockMapper{baseMap}, func() []delegation.Option {
 				return []delegation.Option{delegation.WithNoExpiration()}
 			})
@@ -132,13 +128,6 @@ func TestBucketFallbackMapper(t *testing.T) {
 					claim := testutil.Must(delegation.Extract(decoded.Digest))(t)
 					testutil.RequireEqualDelegation(t, testCase.expectedClaim, claim)
 				}
-			}
-			require.NoError(t, server.Shutdown(ctx))
-			select {
-			case <-ctx.Done():
-				t.Fatal("did not complete shutdown")
-			case err := <-doneErr:
-				require.ErrorIs(t, err, http.ErrServerClosed)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #103 

The original implementation launched an HTTP server for the test concurrently in a different goroutine. This poses a race condition between starting the server and running the tests. Sometimes, the test was run before the server was ready and the test failed.

Finding the cause has been tricky because, in case of an error in the HEAD request, `BucketFallbackMapper` swallows the original error and returns `ErrKeyNotFound`, masking the real cause of the issue. This error handling has been improved to avoid this.

To fix the test, the regular HTTP server being used has been replaced with an `httptest.Server`. It simplifies the test code as handling its shutdown is easier, but the reason it fixes the issue is that `httptest.Server` prepares the network listener synchronously, and then starts the server concurrently. That means that, even in the case the test is run before the server is ready to server requests, the listener will be able to buffer them and prevent the test from failing.