### PR TITLE
fix: make honeycomb API key optional

### DIFF
--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -23,4 +23,5 @@ variable "did" {
 variable "honeycomb_api_key" {
   description = "Ingestion API key to send traces to Honeycomb"
   type = string
+  default = ""
 }

--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -158,7 +158,7 @@ func FromEnv(ctx context.Context) Config {
 		LegacyBlockIndexTableName:   mustGetEnv("LEGACY_BLOCK_INDEX_TABLE_NAME"),
 		LegacyBlockIndexTableRegion: mustGetEnv("LEGACY_BLOCK_INDEX_TABLE_REGION"),
 		LegacyDataBucketURL:         mustGetEnv("LEGACY_DATA_BUCKET_URL"),
-		HoneycombAPIKey:             mustGetEnv("HONEYCOMB_API_KEY"),
+		HoneycombAPIKey:             os.Getenv("HONEYCOMB_API_KEY"),
 	}
 }
 


### PR DESCRIPTION
`.env.local` template says this is optional and the code (mostly) allows this to be optional.