### PR TITLE
fix: region for legacy claims bucket

### DIFF
--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -36,14 +36,14 @@ locals {
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
 }
 
-data "aws_s3_bucket" "legacy_claims_bucket" {
-  provider = aws.legacy_claims
-  bucket = local.inferred_legacy_claims_bucket_name
-}
-
 provider "aws" {
   alias = "legacy_claims"
   region = local.inferred_legacy_claims_table_region
+}
+
+data "aws_s3_bucket" "legacy_claims_bucket" {
+  provider = aws.legacy_claims
+  bucket = local.inferred_legacy_claims_bucket_name
 }
 
 data "aws_dynamodb_table" "legacy_claims_table" {

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -37,6 +37,7 @@ locals {
 }
 
 data "aws_s3_bucket" "legacy_claims_bucket" {
+  provider = aws.legacy_claims
   bucket = local.inferred_legacy_claims_bucket_name
 }
 


### PR DESCRIPTION
If your AWS deployment region is set to `us-west-2` for example, then your deployment will fail because the staging claims bucket is actually in `us-east-2`.