### PR TITLE
chore: resolve docker lint warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye as build
+FROM golang:1.23-bullseye AS build
 
 WORKDIR /go/src/indexing-service
 


### PR DESCRIPTION
```
  1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile:1
--------------------
   1 | >>> FROM golang:1.23-bullseye as build
   2 |     
   3 |     WORKDIR /go/src/indexing-service
--------------------
```