### PR TITLE
feat: configurable principal mapping

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -5,3 +5,6 @@ TF_VAR_did=
 
 # optional - if you want to enable instrumentation (only Honeycomb is supported for now)
 # TF_VAR_honeycomb_api_key=
+
+# optional - JSON encoded mapping of did:web to did:key
+# TF_VAR_principal_mapping=

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,6 +1,0 @@
-package config
-
-var PrincipalMapping = map[string]string{
-	"did:web:staging.upload.storacha.network": "did:key:z6MkqVThfb3PVdgT5yxumxjFFjoQ2vWd26VUQKByPuSB9N91",
-	"did:web:upload.storacha.network":         "did:key:z6MkmbbLigYdv5EuU9tJMDXXUudbySwVNeHNqhQGJs7ALUsF",
-}

--- a/cmd/lambda/postclaims/main.go
+++ b/cmd/lambda/postclaims/main.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
 	ucanserver "github.com/storacha/go-ucanto/server"
-	idxconf "github.com/storacha/indexing-service/cmd/config"
 	"github.com/storacha/indexing-service/cmd/lambda"
 	"github.com/storacha/indexing-service/pkg/aws"
 	"github.com/storacha/indexing-service/pkg/principalresolver"
@@ -22,7 +21,7 @@ func makeHandler(cfg aws.Config) any {
 		panic(err)
 	}
 
-	presolv, err := principalresolver.New(idxconf.PrincipalMapping)
+	presolv, err := principalresolver.New(cfg.PrincipalMapping)
 	if err != nil {
 		panic(fmt.Errorf("creating principal resolver: %w", err))
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,8 +12,8 @@ import (
 	ed25519 "github.com/storacha/go-ucanto/principal/ed25519/signer"
 	"github.com/storacha/go-ucanto/principal/signer"
 	ucanserver "github.com/storacha/go-ucanto/server"
-	"github.com/storacha/indexing-service/cmd/config"
 	"github.com/storacha/indexing-service/pkg/construct"
+	"github.com/storacha/indexing-service/pkg/presets"
 	"github.com/storacha/indexing-service/pkg/principalresolver"
 	"github.com/storacha/indexing-service/pkg/server"
 	"github.com/urfave/cli/v2"
@@ -120,7 +120,7 @@ func main() {
 
 							opts = append(opts, server.WithIdentity(id))
 
-							presolv, err := principalresolver.New(config.PrincipalMapping)
+							presolv, err := principalresolver.New(presets.PrincipalMapping)
 							if err != nil {
 								return fmt.Errorf("creating principal resolver: %w", err)
 							}

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -100,6 +100,7 @@ resource "aws_lambda_function" "lambda" {
         OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/var/task/otel-collector-config.yaml"
         HONEYCOMB_OTLP_ENDPOINT = "api.honeycomb.io:443"
         HONEYCOMB_API_KEY = "${var.honeycomb_api_key}"
+        PRINCIPAL_MAPPING = var.principal_mapping
     }
   }
 

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -25,3 +25,9 @@ variable "honeycomb_api_key" {
   type = string
   default = ""
 }
+
+variable "principal_mapping" {
+  type        = string
+  description = "JSON encoded mapping of did:web to did:key"
+  default     = ""
+}

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -1,0 +1,8 @@
+package presets
+
+var PrincipalMapping = map[string]string{
+	"did:web:staging.up.storacha.network": "did:key:z6MkqVThfb3PVdgT5yxumxjFFjoQ2vWd26VUQKByPuSB9N91",
+	"did:web:up.storacha.network":         "did:key:z6MkmbbLigYdv5EuU9tJMDXXUudbySwVNeHNqhQGJs7ALUsF",
+	"did:web:staging.web3.storage":        "did:key:z6MkqVThfb3PVdgT5yxumxjFFjoQ2vWd26VUQKByPuSB9N91",
+	"did:web:web3.storage":                "did:key:z6MkmbbLigYdv5EuU9tJMDXXUudbySwVNeHNqhQGJs7ALUsF",
+}


### PR DESCRIPTION
Echos the [principal mapping config in storage node](https://github.com/storacha/storage/blob/c234bbbc56915ec40ad3738607d008848f71c136/deploy/app/variables.tf#L89-L93).

Alllows services with did:web keys other than the hard coded defaults to use the indexer.