### PR TITLE
fix: handle non-existent keys properly in Store.SMembers

### DIFF
--- a/pkg/redis/redisstore_test.go
+++ b/pkg/redis/redisstore_test.go
@@ -334,10 +334,25 @@ func (m *MockRedis) SMembers(ctx context.Context, key string) *goredis.StringSli
 	}
 	val, ok := m.data[key]
 	if !ok {
-		cmd.SetErr(goredis.Nil)
+		cmd.SetVal([]string{})
 	} else {
 		values := slices.Collect(maps.Keys(val.data))
 		cmd.SetVal(values)
 	}
+	return cmd
+}
+
+// Exists implements redis.RedisClient.
+func (m *MockRedis) Exists(ctx context.Context, keys ...string) *goredis.IntCmd {
+	cmd := goredis.NewIntCmd(ctx, nil)
+
+	numExisting := int64(0)
+	for _, key := range keys {
+		if _, ok := m.data[key]; ok {
+			numExisting++
+		}
+	}
+	cmd.SetVal(numExisting)
+
 	return cmd
 }

--- a/pkg/redis/redisstore_test.go
+++ b/pkg/redis/redisstore_test.go
@@ -334,25 +334,11 @@ func (m *MockRedis) SMembers(ctx context.Context, key string) *goredis.StringSli
 	}
 	val, ok := m.data[key]
 	if !ok {
+		// SMembers returns an empty set for non-existing keys
 		cmd.SetVal([]string{})
 	} else {
 		values := slices.Collect(maps.Keys(val.data))
 		cmd.SetVal(values)
 	}
-	return cmd
-}
-
-// Exists implements redis.RedisClient.
-func (m *MockRedis) Exists(ctx context.Context, keys ...string) *goredis.IntCmd {
-	cmd := goredis.NewIntCmd(ctx, nil)
-
-	numExisting := int64(0)
-	for _, key := range keys {
-		if _, ok := m.data[key]; ok {
-			numExisting++
-		}
-	}
-	cmd.SetVal(numExisting)
-
 	return cmd
 }


### PR DESCRIPTION
I saw some unexpected traces when debugging some custom instrumentation I'm adding. Basically, the service was not looking for claims in IPNI or legacy systems even though there were no results in the cache.

Turns out that the `SMEMBERS` command doesn't return `(nil)` when the key doesn't exist, as others commands do. Instead, it returns an empty set (see the docs for [SMEMBERS](https://redis.io/docs/latest/commands/smembers/#:~:text=This%20has%20the%20same%20effect%20as%20running%20SINTER%20with%20one%20argument%20key.) and then [SINTER](https://redis.io/docs/latest/commands/sinter/#:~:text=Keys%20that%20do%20not%20exist%20are%20considered%20to%20be%20empty%20sets.)). Therefore, the store was returning an empty slice instead of `ErrKeyNotFound`.

I added an explicit existence check in `SMembers` when the command returns an empty set, assuming that it may be interesting to differentiate between a non-existent and an empty set.