### PR TITLE
fix: blob index compatibility

### DIFF
--- a/pkg/blobindex/shardeddagindex.go
+++ b/pkg/blobindex/shardeddagindex.go
@@ -227,11 +227,12 @@ func Archive(model ShardedDagIndex) (io.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	// add the root block to the block list
-	blks = append(blks, rootBlk)
 
 	// encode the CAR file
 	return car.Encode([]ipld.Link{rootBlk.Link()}, func(yield func(block.Block, error) bool) {
+		if !yield(rootBlk, nil) {
+			return
+		}
 		for _, b := range blks {
 			if !yield(b, nil) {
 				return


### PR DESCRIPTION
JS blob index (the ones we create on the client) encodes the root block as the first block in the CAR not the last.

This PR restores parity with the JS blob index, allowing indexes created using Go to serialize to the same bytes as indexes created by JS and by virtue hash to the same CID:

BEFORE:

<img width="925" alt="Screenshot 2025-02-07 at 15 28 12" src="https://github.com/user-attachments/assets/090801dd-8c08-468e-bf33-751fdc537c58" />

AFTER:

<img width="913" alt="Screenshot 2025-02-07 at 15 27 49" src="https://github.com/user-attachments/assets/36b38642-f936-4836-bce9-36dfd16b8b54" />
