### PR TITLE
fix: allow skipping publish of existing advert

### DIFF
--- a/pkg/service/providerindex/providerindex.go
+++ b/pkg/service/providerindex/providerindex.go
@@ -263,10 +263,13 @@ func (pi *ProviderIndexService) Publish(ctx context.Context, provider peer.AddrI
 
 	id, err := pi.publisher.Publish(ctx, provider, contextID, digests, meta)
 	if err != nil {
-		if !errors.Is(err, publisher.ErrAlreadyAdvertised) {
-			return fmt.Errorf("publishing advert: %w", err)
+		if errors.Is(err, publisher.ErrAlreadyAdvertised) {
+			// skipping is ok in this case
+			log.Warnf("Skipping previously published advert")
+			return nil
 		}
-		log.Warnf("Skipping previously published advert")
+		
+		return fmt.Errorf("publishing advert: %w", err)
 	}
 	log.Infof("published IPNI advert: %s", id)
 	return nil

--- a/pkg/service/providerindex/providerindex.go
+++ b/pkg/service/providerindex/providerindex.go
@@ -38,7 +38,7 @@ type ProviderIndexService struct {
 	findClient    ipnifind.Finder
 	publisher     publisher.Publisher
 	legacyClaims  LegacyClaimsFinder
-	mutex         *sync.Mutex
+	mutex         sync.Mutex
 }
 
 var _ ProviderIndex = (*ProviderIndexService)(nil)
@@ -49,7 +49,6 @@ func New(providerStore types.ProviderStore, findClient ipnifind.Finder, publishe
 		findClient:    findClient,
 		publisher:     publisher,
 		legacyClaims:  legacyClaims,
-		mutex:         &sync.Mutex{},
 	}
 }
 
@@ -268,7 +267,7 @@ func (pi *ProviderIndexService) Publish(ctx context.Context, provider peer.AddrI
 			log.Warnf("Skipping previously published advert")
 			return nil
 		}
-		
+
 		return fmt.Errorf("publishing advert: %w", err)
 	}
 	log.Infof("published IPNI advert: %s", id)

--- a/pkg/service/providerindex/providerindex.go
+++ b/pkg/service/providerindex/providerindex.go
@@ -266,6 +266,7 @@ func (pi *ProviderIndexService) Publish(ctx context.Context, provider peer.AddrI
 		if !errors.Is(err, publisher.ErrAlreadyAdvertised) {
 			return fmt.Errorf("publishing advert: %w", err)
 		}
+		log.Warnf("Skipping previously published advert")
 	}
 	log.Infof("published IPNI advert: %s", id)
 	return nil


### PR DESCRIPTION
If one or multiple users upload the same blob multiple times the `assert/index` invocation will create an advert that already exists. This will cause `ipni-publisher` to return `ErrAlreadyAdvertised` and the invocation fails. This PR ignores `ErrAlreadyAdvertised` because, that's fine, whatever.

It also adds a mutex around publish per https://github.com/storacha/ipni-publisher/issues/3