### PR TITLE
feat: increase concurrency

### DIFF
--- a/pkg/construct/construct.go
+++ b/pkg/construct/construct.go
@@ -421,7 +421,7 @@ func Construct(sc ServiceConfig, opts ...Option) (Service, error) {
 	}
 
 	// with concurrency will still get overridden if a different walker setting is used
-	serviceOpts := append([]service.Option{service.WithConcurrency(5)}, cfg.opts...)
+	serviceOpts := append([]service.Option{service.WithConcurrency(15)}, cfg.opts...)
 
 	s.IndexingService = service.NewIndexingService(blobIndexLookup, claims, publicAddrInfo, providerIndex, serviceOpts...)
 


### PR DESCRIPTION
Traces in prod show queries taking around 9 secs to complete. It is clear from taking a look at the spans that the concurrency level is being hit and an increase could improve query time.

I'm bumping it to 15 for now to test how it goes. We might want to choose an even higher number. Concurrency is based in goroutines, which are very efficient, so it should be possible to go much higher. The limiting factor would probably be networking.