### PR TITLE
feat(provider-index): parallelize claim lookups

### DIFF
--- a/pkg/service/providerindex/providerindex_test.go
+++ b/pkg/service/providerindex/providerindex_test.go
@@ -6,6 +6,7 @@ import (
 	"iter"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/ipni/go-libipni/find/model"
 	"github.com/multiformats/go-multicodec"
@@ -58,12 +59,15 @@ func TestGetProviderResults(t *testing.T) {
 			},
 		}
 
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(ipniFinderResponse, nil)
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return(nil, nil)
 		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
 		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
 
-		results, err := providerIndex.getProviderResults(context.Background(), someHash, []multicodec.Code{metadata.LocationCommitmentID})
+		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
 
 		require.NoError(t, err)
 		require.Equal(t, []model.ProviderResult{expectedResult}, results)
@@ -172,6 +176,7 @@ func TestGetProviderResults(t *testing.T) {
 		someHash := testutil.RandomMultihash()
 
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, []multicodec.Code{0}).Return(nil, nil)
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(nil, errors.New("some error"))
 
 		_, err := providerIndex.getProviderResults(context.Background(), someHash, []multicodec.Code{0})
@@ -217,13 +222,147 @@ func TestGetProviderResults(t *testing.T) {
 			},
 		}
 
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(ipniFinderResponse, nil)
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return(nil, nil)
 		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(0, errors.New("some error"))
 
-		_, err := providerIndex.getProviderResults(context.Background(), someHash, []multicodec.Code{metadata.LocationCommitmentID})
+		_, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
 
 		require.Error(t, err)
+	})
+
+	t.Run("IPNI returns valid result and legacy returns error", func(t *testing.T) {
+		mockStore := types.NewMockProviderStore(t)
+		mockIpniFinder := extmocks.NewMockIpniFinder(t)
+		mockIpniPublisher := extmocks.NewMockIpniPublisher(t)
+		mockLegacyClaims := NewMockLegacyClaimsFinder(t)
+
+		providerIndex := New(mockStore, mockIpniFinder, mockIpniPublisher, mockLegacyClaims)
+
+		someHash := testutil.RandomMultihash()
+		expectedResult := testutil.RandomLocationCommitmentProviderResult()
+		ipniResponse := &model.FindResponse{
+			MultihashResults: []model.MultihashResult{
+				{
+					Multihash:       someHash,
+					ProviderResults: []model.ProviderResult{expectedResult},
+				},
+			},
+		}
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
+		// Simulate a cache miss.
+		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		// IPNI returns a valid result.
+		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(ipniResponse, nil)
+		// Legacy returns an error.
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return(nil, errors.New("legacy error"))
+		// Expect caching of the IPNI result.
+		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
+		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
+
+		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
+		require.NoError(t, err)
+		require.Equal(t, []model.ProviderResult{expectedResult}, results)
+	})
+
+	t.Run("legacy returns valid result and IPNI returns error", func(t *testing.T) {
+		mockStore := types.NewMockProviderStore(t)
+		mockIpniFinder := extmocks.NewMockIpniFinder(t)
+		mockIpniPublisher := extmocks.NewMockIpniPublisher(t)
+		mockLegacyClaims := NewMockLegacyClaimsFinder(t)
+
+		providerIndex := New(mockStore, mockIpniFinder, mockIpniPublisher, mockLegacyClaims)
+
+		someHash := testutil.RandomMultihash()
+		expectedResult := testutil.RandomLocationCommitmentProviderResult()
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
+		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		// IPNI returns an error.
+		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(nil, errors.New("ipni error"))
+		// Legacy returns a valid result.
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return([]model.ProviderResult{expectedResult}, nil)
+		// Expect caching of the legacy result.
+		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
+		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
+
+		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
+		require.NoError(t, err)
+		require.Equal(t, []model.ProviderResult{expectedResult}, results)
+	})
+
+	t.Run("both queries error", func(t *testing.T) {
+		mockStore := types.NewMockProviderStore(t)
+		mockIpniFinder := extmocks.NewMockIpniFinder(t)
+		mockIpniPublisher := extmocks.NewMockIpniPublisher(t)
+		mockLegacyClaims := NewMockLegacyClaimsFinder(t)
+
+		providerIndex := New(mockStore, mockIpniFinder, mockIpniPublisher, mockLegacyClaims)
+
+		someHash := testutil.RandomMultihash()
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
+		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		// Both queries error.
+		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(nil, errors.New("ipni error"))
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return(nil, errors.New("legacy error"))
+
+		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
+		require.Nil(t, results)
+		require.Error(t, err)
+		// Verify that the final error message contains both errors.
+		require.Contains(t, err.Error(), "fetching from IPNI failed: ipni error")
+		require.Contains(t, err.Error(), "fetching from legacy services failed: legacy error")
+	})
+
+	t.Run("IPNI returns result before legacy is complete and legacy is canceled", func(t *testing.T) {
+		mockStore := types.NewMockProviderStore(t)
+		mockIpniFinder := extmocks.NewMockIpniFinder(t)
+		mockIpniPublisher := extmocks.NewMockIpniPublisher(t)
+		mockLegacyClaims := NewMockLegacyClaimsFinder(t)
+
+		providerIndex := New(mockStore, mockIpniFinder, mockIpniPublisher, mockLegacyClaims)
+
+		someHash := testutil.RandomMultihash()
+		expectedResult := testutil.RandomLocationCommitmentProviderResult()
+		ipniResponse := &model.FindResponse{
+			MultihashResults: []model.MultihashResult{
+				{
+					Multihash:       someHash,
+					ProviderResults: []model.ProviderResult{expectedResult},
+				},
+			},
+		}
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
+		// Simulate a cache miss.
+		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		// IPNI returns immediately with a valid result.
+		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(ipniResponse, nil)
+		// Legacy query simulates a delay and then returns, but will be canceled.
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).
+			RunAndReturn(func(ctx context.Context, mh multihash.Multihash, targetClaims []multicodec.Code) ([]model.ProviderResult, error) {
+				// Wait for cancellation.
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(100 * time.Millisecond):
+					// This branch should not be reached if cancellation works.
+					t.Fatal("legacy services returned a result when it should have been canceled by success of IPNI query")
+				}
+				return nil, nil
+			})
+		// Expect caching of the IPNI result.
+		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
+		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
+
+		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
+		require.NoError(t, err)
+		require.Equal(t, []model.ProviderResult{expectedResult}, results)
 	})
 }
 


### PR DESCRIPTION
via 656fa6769c5dad56e2a99590930f09dd2f324e1b
- ProviderIndexService.getProviderResults now queries IPNI and legacy claims concurrently using channels. If IPNI returns a valid result, the legacy lookup is canceled.
- errors from both queries are joined to provide better context when neither returns data.
- tests have been updated to cover these new scenarios.
- closes #120 

via ae21e4484301fc1f3f8f869f256e52d9e27ae560 
- adds a few more events to the span for the operation be modified allowing timing of various operations to be inferred. If we prefer this change be landed separately (or not at all!) happy to revert it.