### PR TITLE
fix: use the provided context in HTTP requests

### DIFF
--- a/pkg/aws/bucketfallbackmapper.go
+++ b/pkg/aws/bucketfallbackmapper.go
@@ -35,7 +35,12 @@ func NewBucketFallbackMapper(id principal.Signer, httpClient *http.Client, bucke
 }
 
 func (cfm BucketFallbackMapper) GetClaims(ctx context.Context, contentHash multihash.Multihash) ([]cid.Cid, error) {
-	resp, err := cfm.httpClient.Head(cfm.bucketURL.JoinPath(toBlobKey(contentHash)).String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, cfm.bucketURL.JoinPath(toBlobKey(contentHash)).String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cfm.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/contentclaims/simplefinder.go
+++ b/pkg/service/contentclaims/simplefinder.go
@@ -28,7 +28,12 @@ func NewSimpleFinder(httpClient *http.Client) Finder {
 // Find attempts to fetch a claim from the provided URL.
 func (sf *simpleFinder) Find(ctx context.Context, id ipld.Link, fetchURL *url.URL) (delegation.Delegation, error) {
 	// attempt to fetch the claim from provided url
-	resp, err := sf.httpClient.Get(fetchURL.String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := sf.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch claim: %w", err)
 	}


### PR DESCRIPTION
Thinking specifically of enabling cancellation of the request by cancelling the provided context.

`BucketFallbackMapper` is used by the legacy claims logic, and now that #122 will make that run in parallel with the query to IPNI and can potentially be cancelled, I took a look at the context propagation chain and noticed we were not using it in these calls.