### PR TITLE
Override data bucket url

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -8,3 +8,10 @@ TF_VAR_did=
 
 # optional - JSON encoded mapping of did:web to did:key
 # TF_VAR_principal_mapping=
+
+# optional - Vars to reconfigure the mappings for legacy claims
+# TF_VAR_legacy_claims_bucket_name=
+# TF_VAR_legacy_block_index_table_name=
+# TF_VAR_legacy_claims_table_name=
+# TF_VAR_legacy_claims_table_region=
+# TF_VAR_legacy_data_bucket_url=

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -93,7 +93,7 @@ resource "aws_lambda_function" "lambda" {
         LEGACY_CLAIMS_BUCKET_NAME = data.aws_s3_bucket.legacy_claims_bucket.id
         LEGACY_BLOCK_INDEX_TABLE_NAME = data.aws_dynamodb_table.legacy_block_index_table.id
         LEGACY_BLOCK_INDEX_TABLE_REGION = data.aws_region.block_index.name
-        LEGACY_DATA_BUCKET_URL = "https://carpark-${terraform.workspace == "prod" ? "prod" : "staging"}-0.r2.w3s.link"
+        LEGACY_DATA_BUCKET_URL = var.legacy_data_bucket_url != "" ? var.legacy_data_bucket_url : "https://carpark-${terraform.workspace == "prod" ? "prod" : "staging"}-0.r2.w3s.link"
         GOLOG_LOG_LEVEL = terraform.workspace == "prod" ? "error" : "debug"
         OTEL_PROPAGATORS = "tracecontext"
         OTEL_SERVICE_NAME = "${terraform.workspace}-${var.app}"

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -31,3 +31,9 @@ variable "principal_mapping" {
   description = "JSON encoded mapping of did:web to did:key"
   default     = ""
 }
+
+variable "legacy_data_bucket_url" {
+  type = string
+  description = "URL to use when constructing synthesizing legacy claims"
+  default = ""
+}


### PR DESCRIPTION
# Goals

Enable setting the carpark to use for the LEGACY_DATA_BUCKET_URL. This simply completes the set of vars needed to fully complete custom configuration of legacy lookups

Useful for local testing downstream services like Freeway against prod data, but without using the prod service

# Implementation

- add a var for legacy data bucket url
- use legacy data bucket url when configured