### PR TITLE
feat(redis): enable tuning of caching parameters

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -70,10 +70,13 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       	PROVIDERS_REDIS_URL = aws_elasticache_serverless_cache.cache["providers"].endpoint[0].address
         PROVIDERS_REDIS_CACHE = aws_elasticache_serverless_cache.cache["providers"].name
+        PROVIDERS_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 30 * 24 * 60 * 60 : 24 * 60 * 60}"
         INDEXES_REDIS_URL = aws_elasticache_serverless_cache.cache["indexes"].endpoint[0].address
         INDEXES_REDIS_CACHE = aws_elasticache_serverless_cache.cache["indexes"].name
+        INDEXES_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 24 * 60 * 60 : 60 * 60}"
         CLAIMS_REDIS_URL = aws_elasticache_serverless_cache.cache["claims"].endpoint[0].address
         CLAIMS_REDIS_CACHE = aws_elasticache_serverless_cache.cache["claims"].name
+        CLAIMS_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 7 * 24 * 60 * 60 : 24 * 60 * 60}"
         REDIS_USER_ID = aws_elasticache_user.cache_iam_user.user_id
         IPNI_ENDPOINT = "https://cid.contact"
         PROVIDER_CACHING_QUEUE_URL = aws_sqs_queue.caching.id

--- a/pkg/redis/contentclaimsstore.go
+++ b/pkg/redis/contentclaimsstore.go
@@ -14,8 +14,8 @@ var _ types.ContentClaimsCache = (*ContentClaimsStore)(nil)
 type ContentClaimsStore = Store[cid.Cid, delegation.Delegation]
 
 // NewContentClaimsStore returns a new instance of a Content Claims Store using the given redis client
-func NewContentClaimsStore(client Client) *ContentClaimsStore {
-	return &Store[cid.Cid, delegation.Delegation]{delegationFromRedis, delegationToRedis, cidKeyString, client}
+func NewContentClaimsStore(client Client, opts ...Option) *ContentClaimsStore {
+	return NewStore(delegationFromRedis, delegationToRedis, cidKeyString, client, opts...)
 }
 
 func delegationFromRedis(data string) (delegation.Delegation, error) {

--- a/pkg/redis/providerstore.go
+++ b/pkg/redis/providerstore.go
@@ -18,8 +18,8 @@ var (
 type ProviderStore = Store[multihash.Multihash, model.ProviderResult]
 
 // NewProviderStore returns a new instance of an IPNI store using the given redis client
-func NewProviderStore(client Client) *ProviderStore {
-	return NewStore(providerResultFromRedis, providerResultToRedis, multihashKeyString, client)
+func NewProviderStore(client Client, opts ...Option) *ProviderStore {
+	return NewStore(providerResultFromRedis, providerResultToRedis, multihashKeyString, client, opts...)
 }
 
 func providerResultFromRedis(data string) (model.ProviderResult, error) {

--- a/pkg/redis/shareddagindexstore.go
+++ b/pkg/redis/shareddagindexstore.go
@@ -16,8 +16,8 @@ var (
 type ShardedDagIndexStore = Store[types.EncodedContextID, blobindex.ShardedDagIndexView]
 
 // NewShardedDagIndexStore returns a new instance of a ShardedDagIndex store using the given redis client
-func NewShardedDagIndexStore(client Client) *ShardedDagIndexStore {
-	return &Store[types.EncodedContextID, blobindex.ShardedDagIndexView]{shardedDagIndexFromRedis, shardedDagIndexToRedis, encodedContextIDKeyString, client}
+func NewShardedDagIndexStore(client Client, opts ...Option) *ShardedDagIndexStore {
+	return NewStore(shardedDagIndexFromRedis, shardedDagIndexToRedis, encodedContextIDKeyString, client, opts...)
 }
 
 func shardedDagIndexFromRedis(data string) (blobindex.ShardedDagIndexView, error) {


### PR DESCRIPTION
# Goals

Currently, our cache hit rate for some of our redis instances is really low, because it turns out 1 hour really isn't long enough to hold some of this data. There's not reason not to hold it longer -- we've allocated almost 10GB to these redis instances and we're currently using all of a couple MB.

![Screenshot 2025-02-13 at 1 30 19 PM](https://github.com/user-attachments/assets/efdd0b1f-9f57-478f-a796-31b8145189df)

# Implementation

- Enable passing a specific expiration parameter to each redis store
- Pipe all the way out to an AWS env var
- Up expirations times to:
  - 1 month on prod, 1 week on staging for providers (very small data)
  - 1 week on prod, 1 day on staging for claims
  - 1 day on prod, 1 hour on staging for indexes (larger data)