### PR TITLE
fix: ensure shutdown functions are called when lambdas are destroyed

### DIFF
--- a/cmd/lambda/start.go
+++ b/cmd/lambda/start.go
@@ -26,12 +26,13 @@ func Start(makeHandler handlerFactory) {
 		if err != nil {
 			panic(err)
 		}
-		defer telemetryShutdown(ctx)
 
 		handler := makeHandler(cfg)
 		instrumentedHandler := telemetry.InstrumentLambdaHandler(handler)
 
-		lambda.StartWithOptions(instrumentedHandler, lambda.WithContext(ctx))
+		lambda.StartWithOptions(instrumentedHandler, lambda.WithContext(ctx), lambda.WithEnableSIGTERM(func() {
+			telemetryShutdown(ctx)
+		}))
 	} else {
 		lambda.StartWithOptions(makeHandler(cfg), lambda.WithContext(ctx))
 	}


### PR DESCRIPTION
I confirmed with some experimentation that deferring the call doesn't work. The`lambda.Start` call never returns.