### PR TITLE
fix: distributed tracing not working

### DIFF
--- a/pkg/telemetry/otel.go
+++ b/pkg/telemetry/otel.go
@@ -46,7 +46,12 @@ func SetupTelemetry(ctx context.Context, cfg *aws.Config) (func(context.Context)
 	)
 	otel.SetTextMapPropagator(prop)
 
+	// We'll use a ParentBased(AlwaysSample) Sampler (which is the default, doing it explicitly here for readability).
+	// This means this service will export spans if the upstream service has sampled the request.
+	// Requests that are NOT coming from an upstream service, however, will always be sampled. This allows producing
+	// traces for manual queries, which is useful for debugging.
 	tp := tracesdk.NewTracerProvider(
+		tracesdk.WithSampler(tracesdk.ParentBased(tracesdk.AlwaysSample())),
 		tracesdk.WithBatcher(exp),
 		tracesdk.WithResource(resource),
 	)


### PR DESCRIPTION
fixes #134 

Context propagation was not properly configured and incoming trace context was not being extracted from requests coming from the gateway.

Interestingly, telemetry was already configured to sample only requests that were sampled in the upstream service, but since context propagation was not working the result was that all requests were being sampled. Fixing context propagation also means that the indexer will only sample requests that are sampled in the gateway.