### PR TITLE
chore: upgrade go-ucanto to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/storacha/indexing-service
 
-go 1.23.2
+go 1.23.3
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0
@@ -30,7 +30,7 @@ require (
 	github.com/redis/go-redis/extra/redisotel/v9 v9.7.0
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/storacha/go-libstoracha v0.0.1
-	github.com/storacha/go-ucanto v0.2.1-0.20241105025747-aa8566a3a3fb
+	github.com/storacha/go-ucanto v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/dynamodb v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -675,6 +675,8 @@ github.com/storacha/go-libstoracha v0.0.1 h1:cVt9FAU+WD0yu9JO4hcmaW87RTO1p3pHDwd
 github.com/storacha/go-libstoracha v0.0.1/go.mod h1:AsPBhhzmzG48XdydXeiKemk2xnyPS7qvC7jH4+cu4Ek=
 github.com/storacha/go-ucanto v0.2.1-0.20241105025747-aa8566a3a3fb h1:aVHQtqE67jU9krIyZBYwFgFq+bkzEu66O0hrpTO5beQ=
 github.com/storacha/go-ucanto v0.2.1-0.20241105025747-aa8566a3a3fb/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
+github.com/storacha/go-ucanto v0.3.0 h1:m4jDVREdA6VjcI+j3/lMmRDCmP8gijDk+EkzzC6ANBU=
+github.com/storacha/go-ucanto v0.3.0/go.mod h1:kslS8xldf12d2D4kj0wBfOvAP1gftzMjTxBdJwGKwZE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
Upgrade `go-ucanto` to the latest version to get the fix for the server not validating invocation audiences (https://github.com/storacha/go-ucanto/pull/38).