### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.5.0"
+  "version": "v1.6.0"
 }


### PR DESCRIPTION
Releasing v1.6.0 to deploy the fix to distributed tracing, caching claims generated from the blob index table and the go-ucanto fixes.

Currently telemetry is disabled in prod and merging this will re-enable it. I'll keep an eye on honeycomb to confirm the fix is working and the indexer is sampling only the traces that are sampled in the gateway.