### PR TITLE
fix: reduce providers cache entry expiration to 1 day

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -70,7 +70,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       	PROVIDERS_REDIS_URL = aws_elasticache_serverless_cache.cache["providers"].endpoint[0].address
         PROVIDERS_REDIS_CACHE = aws_elasticache_serverless_cache.cache["providers"].name
-        PROVIDERS_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 30 * 24 * 60 * 60 : 24 * 60 * 60}"
+        PROVIDERS_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 24 * 60 * 60 : 24 * 60 * 60}"
         INDEXES_REDIS_URL = aws_elasticache_serverless_cache.cache["indexes"].endpoint[0].address
         INDEXES_REDIS_CACHE = aws_elasticache_serverless_cache.cache["indexes"].name
         INDEXES_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 24 * 60 * 60 : 60 * 60}"


### PR DESCRIPTION
we are seeing poor hit rates in the providers cache and want to try reducing the expiration to see the effect it has while we investigate the issue.