### PR TITLE
fix: increase provider cache size

### DIFF
--- a/deploy/app/elasticcache.tf
+++ b/deploy/app/elasticcache.tf
@@ -13,7 +13,7 @@ resource "aws_elasticache_serverless_cache" "cache" {
   name = "${terraform.workspace}-${var.app}-${each.key}-cache"
   cache_usage_limits {
     data_storage {
-      maximum = terraform.workspace == "prod" ? 10 : 1
+      maximum = terraform.workspace == "prod" ? 20 : 1
       unit = "GB"
     }
     ecpu_per_second {


### PR DESCRIPTION
Provider cache metrics show that the hit rate increased when we started caching results from the block index table, but then decreased again shortly after the cache was full. This might suggest poor hit rates could come from keys being evicted due to not having enough space. The evicted key count seems to support this hypothesis, with around 3000 keys being evicted per hour due to memory constraints.