### PR TITLE
fix: peer ID in legacy synthesized provider result

### DIFF
--- a/pkg/service/providerindex/legacy.go
+++ b/pkg/service/providerindex/legacy.go
@@ -27,8 +27,8 @@ import (
 	"github.com/storacha/go-ucanto/did"
 )
 
-// PeerID is the peer ID used in synthetized provider results.
-var PeerID, _ = peer.Decode("12D3KooWLrikEsjt5wz326bRhCyEThRhJ936o13c5Ej7ttLbkxgp")
+// ProviderID is the peer ID used in synthetized provider results.
+var ProviderID, _ = peer.Decode("12D3KooWLrikEsjt5wz326bRhCyEThRhJ936o13c5Ej7ttLbkxgp")
 
 var ErrIgnoreFiltered = errors.New("claim type is not in list of target claims")
 
@@ -237,7 +237,7 @@ func (ls LegacyClaimsStore) synthetizeLocationProviderResult(caveats assert.Loca
 	providerAddrs = append(providerAddrs, ls.claimsAddr)
 
 	providerAddrInfo := &peer.AddrInfo{
-		ID:    PeerID,
+		ID:    ProviderID,
 		Addrs: providerAddrs,
 	}
 
@@ -264,7 +264,7 @@ func (ls LegacyClaimsStore) synthetizeIndexProviderResult(caveats assert.IndexCa
 
 	// the index claim is fetchable from the legacy claims store
 	providerAddrInfo := &peer.AddrInfo{
-		ID:    PeerID,
+		ID:    ProviderID,
 		Addrs: []ma.Multiaddr{ls.claimsAddr},
 	}
 
@@ -291,7 +291,7 @@ func (ls LegacyClaimsStore) synthetizeEqualsProviderResult(caveats assert.Equals
 
 	// the equals claim is fetchable from the legacy claims store
 	providerAddrInfo := &peer.AddrInfo{
-		ID:    PeerID,
+		ID:    ProviderID,
 		Addrs: []ma.Multiaddr{ls.claimsAddr},
 	}
 

--- a/pkg/service/providerindex/legacy.go
+++ b/pkg/service/providerindex/legacy.go
@@ -27,6 +27,9 @@ import (
 	"github.com/storacha/go-ucanto/did"
 )
 
+// PeerID is the peer ID used in synthetized provider results.
+var PeerID, _ = peer.Decode("12D3KooWLrikEsjt5wz326bRhCyEThRhJ936o13c5Ej7ttLbkxgp")
+
 var ErrIgnoreFiltered = errors.New("claim type is not in list of target claims")
 
 // LegacyClaimsFinder is a read-only interface to find claims on a legacy system
@@ -234,7 +237,7 @@ func (ls LegacyClaimsStore) synthetizeLocationProviderResult(caveats assert.Loca
 	providerAddrs = append(providerAddrs, ls.claimsAddr)
 
 	providerAddrInfo := &peer.AddrInfo{
-		ID:    "",
+		ID:    PeerID,
 		Addrs: providerAddrs,
 	}
 
@@ -261,7 +264,7 @@ func (ls LegacyClaimsStore) synthetizeIndexProviderResult(caveats assert.IndexCa
 
 	// the index claim is fetchable from the legacy claims store
 	providerAddrInfo := &peer.AddrInfo{
-		ID:    "",
+		ID:    PeerID,
 		Addrs: []ma.Multiaddr{ls.claimsAddr},
 	}
 
@@ -288,7 +291,7 @@ func (ls LegacyClaimsStore) synthetizeEqualsProviderResult(caveats assert.Equals
 
 	// the equals claim is fetchable from the legacy claims store
 	providerAddrInfo := &peer.AddrInfo{
-		ID:    "",
+		ID:    PeerID,
 		Addrs: []ma.Multiaddr{ls.claimsAddr},
 	}
 

--- a/pkg/service/providerindex/legacy_test.go
+++ b/pkg/service/providerindex/legacy_test.go
@@ -184,6 +184,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		blobUrl := testutil.Must(url.Parse("https://storacha.network/blobs/{blob}"))(t)
 		blobProviderAddr := testutil.Must(maurl.FromURL(blobUrl))(t)
 		require.Equal(t, blobProviderAddr, result.Provider.Addrs[0])
+		require.Equal(t, PeerID, result.Provider.ID)
 	})
 
 	t.Run("filters out location claims", func(t *testing.T) {
@@ -231,6 +232,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		claimsUrl := testutil.Must(url.Parse("https://storacha.network/claims/{claim}"))(t)
 		claimsProviderAddr := testutil.Must(maurl.FromURL(claimsUrl))(t)
 		require.Equal(t, claimsProviderAddr, result.Provider.Addrs[0])
+		require.Equal(t, PeerID, result.Provider.ID)
 	})
 
 	t.Run("filters out index claims", func(t *testing.T) {
@@ -279,6 +281,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		claimsUrl := testutil.Must(url.Parse("https://storacha.network/claims/{claim}"))(t)
 		claimsProviderAddr := testutil.Must(maurl.FromURL(claimsUrl))(t)
 		require.Equal(t, claimsProviderAddr, result.Provider.Addrs[0])
+		require.Equal(t, PeerID, result.Provider.ID)
 	})
 
 	t.Run("filters out equals claims", func(t *testing.T) {

--- a/pkg/service/providerindex/legacy_test.go
+++ b/pkg/service/providerindex/legacy_test.go
@@ -184,7 +184,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		blobUrl := testutil.Must(url.Parse("https://storacha.network/blobs/{blob}"))(t)
 		blobProviderAddr := testutil.Must(maurl.FromURL(blobUrl))(t)
 		require.Equal(t, blobProviderAddr, result.Provider.Addrs[0])
-		require.Equal(t, PeerID, result.Provider.ID)
+		require.Equal(t, ProviderID, result.Provider.ID)
 	})
 
 	t.Run("filters out location claims", func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		claimsUrl := testutil.Must(url.Parse("https://storacha.network/claims/{claim}"))(t)
 		claimsProviderAddr := testutil.Must(maurl.FromURL(claimsUrl))(t)
 		require.Equal(t, claimsProviderAddr, result.Provider.Addrs[0])
-		require.Equal(t, PeerID, result.Provider.ID)
+		require.Equal(t, ProviderID, result.Provider.ID)
 	})
 
 	t.Run("filters out index claims", func(t *testing.T) {
@@ -281,7 +281,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		claimsUrl := testutil.Must(url.Parse("https://storacha.network/claims/{claim}"))(t)
 		claimsProviderAddr := testutil.Must(maurl.FromURL(claimsUrl))(t)
 		require.Equal(t, claimsProviderAddr, result.Provider.Addrs[0])
-		require.Equal(t, PeerID, result.Provider.ID)
+		require.Equal(t, ProviderID, result.Provider.ID)
 	})
 
 	t.Run("filters out equals claims", func(t *testing.T) {


### PR DESCRIPTION
Fixes the empty peer ID which should allow the indexer to process records in the queue.

> deserializing message: failed to parse peer ID: invalid cid: cid too short
> https://github.com/storacha/indexing-service/blob/04ac62a233322607e72eb592c11d9b59d742bef8/pkg/aws/sqscachingqueue.go#L120

The hard coded peer ID is actually the peer ID of the storage node we'll be deploying to production shortly.