### PR TITLE
chore: increase providercache lambda timeout

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -17,6 +17,7 @@ locals {
     }
     providercache = {
       name = "providercache"
+      timeout = 300
     }
     remotesync = {
       name = "remotesync"


### PR DESCRIPTION
Has been observed to take >30s - increase to 5 minutes.

<img width="470" alt="Screenshot 2025-03-12 at 14 53 56" src="https://github.com/user-attachments/assets/8f938c08-0df4-48c5-aa4f-3b59f2470382" />

