### PR TITLE
perf: discard caching jobs that will timeout

### DIFF
--- a/cmd/lambda/providercache/main.go
+++ b/cmd/lambda/providercache/main.go
@@ -68,7 +68,12 @@ func handleMessage(ctx context.Context, sqsCachingDecoder *aws.SQSCachingDecoder
 	if err != nil {
 		return err
 	}
-	_, err = providerCacher.CacheProviderForIndexRecords(ctx, job.Provider, job.Index)
+	n, err := providerCacher.CacheProviderForIndexRecords(ctx, job.Provider, job.Index)
+	// If we cached 1 or more records then succeed. We don't need to hold up the
+	// queue by re-attempting a cache operation.
+	if n > 0 {
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/lambda/providercache/main.go
+++ b/cmd/lambda/providercache/main.go
@@ -87,7 +87,7 @@ func handleMessage(ctx context.Context, sqsCachingDecoder *aws.SQSCachingDecoder
 	// Do not hold up the queue by re-attempting a cache job that times out. It is
 	// probably a big DAG and retrying is unlikely to subsequently succeed.
 	if errors.Is(err, context.DeadlineExceeded) {
-		log.Warn("not retrying cache provider job for: %s error: %s", job.Index.Content(), err)
+		log.Warnf("not retrying cache provider job for: %s error: %s", job.Index.Content(), err)
 		return nil
 	}
 	if err != nil {

--- a/pkg/service/providercacher/simpleprovidercacher.go
+++ b/pkg/service/providercacher/simpleprovidercacher.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/ipni/go-libipni/find/model"
+	"github.com/multiformats/go-multihash"
 	"github.com/storacha/indexing-service/pkg/blobindex"
+	"github.com/storacha/indexing-service/pkg/internal/link"
 	"github.com/storacha/indexing-service/pkg/types"
 )
 
@@ -18,20 +20,40 @@ func NewSimpleProviderCacher(providerStore types.ProviderStore) ProviderCacher {
 
 func (s *simpleProviderCacher) CacheProviderForIndexRecords(ctx context.Context, provider model.ProviderResult, index blobindex.ShardedDagIndexView) (uint64, error) {
 	written := uint64(0)
+
+	// Prioritize the root
+	rootDigest := link.ToCID(index.Content()).Hash()
+	err := addExpirable(ctx, s.providerStore, rootDigest, provider)
+	if err != nil {
+		return written, err
+	}
+	written++
+
 	for _, shardIndex := range index.Shards().Iterator() {
 		for hash := range shardIndex.Iterator() {
-			n, err := s.providerStore.Add(ctx, hash, provider)
-			written += n
+			if string(hash) == string(rootDigest) {
+				continue // already added
+			}
+			err := addExpirable(ctx, s.providerStore, hash, provider)
 			if err != nil {
 				return written, err
 			}
-			if n > 0 {
-				err = s.providerStore.SetExpirable(ctx, hash, true)
-				if err != nil {
-					return written, err
-				}
-			}
+			written++
 		}
 	}
 	return written, nil
+}
+
+func addExpirable(ctx context.Context, providerStore types.ProviderStore, digest multihash.Multihash, provider model.ProviderResult) error {
+	n, err := providerStore.Add(ctx, digest, provider)
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		err = providerStore.SetExpirable(ctx, digest, true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
1. Prioritize caching the DAG root.
    - This is oftentimes the multihash that'll be queried to obtain the index.
2. Do not hold up the queue on lambda timeout.
    - This is probably a massive DAG that'll exceed lambda timeout. Retrying will cost more writes, probably still not succeed and hold up the fifo queue.

This also adds a graceful shutdown period - [context is canceled before the lambda times out](https://medium.com/@filiplubniewski/how-to-leverage-aws-lambda-timeouts-with-go-context-cancellation-7dacde656540). This allows the cache provider lambda to inspect the error and succeed anyway.