### PR TITLE
chore: release v1.6.3

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.6.2"
+  "version": "v1.6.3"
 }


### PR DESCRIPTION
Releases timeout increase for provider caching consumer lambda and an optimization to prioritise caching the root CID and not retrying huge cache jobs that will hold up the queue.