### PR TITLE
fix: report failures so successfully cached provider info is not retried

### DIFF
--- a/cmd/lambda/providercache/main.go
+++ b/cmd/lambda/providercache/main.go
@@ -25,11 +25,6 @@ func main() {
 	lambda.Start(makeHandler)
 }
 
-type handlerResult struct {
-	id  string
-	err error
-}
-
 func makeHandler(cfg aws.Config) any {
 	providersRedis := goredis.NewClient(&cfg.ProvidersRedis)
 	if cfg.HoneycombAPIKey != "" {
@@ -49,6 +44,11 @@ func makeHandler(cfg aws.Config) any {
 				defer cancel()
 				ctx = dctx
 			}
+		}
+
+		type handlerResult struct {
+			id  string
+			err error
 		}
 
 		// process messages in parallel


### PR DESCRIPTION
Return the failed items on error so that the successful items are not retried.