### PR TITLE
fix: enable batch item failure reporting

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -365,6 +365,7 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
   enabled          = true
   function_name    = aws_lambda_function.lambda["providercache"].arn
   batch_size       = terraform.workspace == "prod" ? 10 : 1
+  function_response_types = ["ReportBatchItemFailures"]
 }
 
 resource "aws_cloudwatch_event_rule" "head_check" {


### PR DESCRIPTION
I read about how to do this on stackoverflow but I missed the bit about configuring the event source mapping. 🤦 sorry.

> To activate partial batch reporting
> [...]
> Run the following command to activate `ReportBatchItemFailures` for your function.

https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-batchfailurereporting