### PR TITLE
fix: do not return error for item failures

### DIFF
--- a/cmd/lambda/providercache/main.go
+++ b/cmd/lambda/providercache/main.go
@@ -82,7 +82,7 @@ func makeHandler(cfg aws.Config) any {
 		if err != nil {
 			log.Errorf("handling messages: %s", err.Error())
 		}
-		return events.SQSEventResponse{BatchItemFailures: batchItemFailures}, err
+		return events.SQSEventResponse{BatchItemFailures: batchItemFailures}, nil
 	}
 }
 


### PR DESCRIPTION
🤷‍♂️ I wondered if this was necessary...looks as though it is.

> Update your function code to catch all exceptions

https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-batchfailurereporting