### PR TITLE
fix(sqs): adjust visibility timeout to lambda timeout

### DIFF
--- a/deploy/app/sqs.tf
+++ b/deploy/app/sqs.tf
@@ -4,6 +4,7 @@ resource "aws_sqs_queue" "caching" {
   name = "${terraform.workspace}-${var.app}-caching.fifo"
   fifo_queue = true
   content_based_deduplication = true
+  visibility_timeout_seconds = 300
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.caching_deadletter.arn
     maxReceiveCount     = 4


### PR DESCRIPTION
We increased the providercache lambda timeout to 300s but didn't update the visibility timeout in the SQS queue it is consuming messages from. That makes the message in the batch being processed available to other lambdas before the one processing them has the chance to delete them and/or mark them as processed.