### PR TITLE
perf: concurrent provider cache

### DIFF
--- a/pkg/service/providercacher/simpleprovidercacher.go
+++ b/pkg/service/providercacher/simpleprovidercacher.go
@@ -44,7 +44,6 @@ func (s *simpleProviderCacher) CacheProviderForIndexRecords(ctx context.Context,
 			mutex.Unlock()
 			return nil
 		}),
-		jobqueue.WithBuffer(5),
 		jobqueue.WithConcurrency(cacherConcurrency),
 		jobqueue.WithErrorHandler(func(err error) {
 			mutex.Lock()

--- a/pkg/service/providercacher/simpleprovidercacher.go
+++ b/pkg/service/providercacher/simpleprovidercacher.go
@@ -2,13 +2,23 @@ package providercacher
 
 import (
 	"context"
+	"errors"
+	"sync"
 
 	"github.com/ipni/go-libipni/find/model"
 	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-libstoracha/jobqueue"
 	"github.com/storacha/indexing-service/pkg/blobindex"
 	"github.com/storacha/indexing-service/pkg/internal/link"
 	"github.com/storacha/indexing-service/pkg/types"
 )
+
+var cacherConcurrency = 5
+
+type digestProviderJob struct {
+	digest   multihash.Multihash
+	provider model.ProviderResult
+}
 
 type simpleProviderCacher struct {
 	providerStore types.ProviderStore
@@ -19,29 +29,50 @@ func NewSimpleProviderCacher(providerStore types.ProviderStore) ProviderCacher {
 }
 
 func (s *simpleProviderCacher) CacheProviderForIndexRecords(ctx context.Context, provider model.ProviderResult, index blobindex.ShardedDagIndexView) (uint64, error) {
-	written := uint64(0)
+	var mutex sync.Mutex
+	var written uint64
+	var jobErr error
+
+	jq := jobqueue.NewJobQueue[digestProviderJob](
+		jobqueue.JobHandler(func(ctx context.Context, job digestProviderJob) error {
+			n, err := addExpirable(ctx, s.providerStore, job.digest, job.provider)
+			if err != nil {
+				return err
+			}
+			mutex.Lock()
+			written += n
+			mutex.Unlock()
+			return nil
+		}),
+		jobqueue.WithBuffer(5),
+		jobqueue.WithConcurrency(cacherConcurrency),
+		jobqueue.WithErrorHandler(func(err error) {
+			mutex.Lock()
+			jobErr = errors.Join(err)
+			mutex.Unlock()
+		}))
+
+	jq.Startup()
 
 	// Prioritize the root
 	rootDigest := link.ToCID(index.Content()).Hash()
-	n, err := addExpirable(ctx, s.providerStore, rootDigest, provider)
-	if err != nil {
-		return written, err
-	}
-	written += n
+	jq.Queue(ctx, digestProviderJob{rootDigest, provider})
 
 	for _, shardIndex := range index.Shards().Iterator() {
 		for hash := range shardIndex.Iterator() {
 			if string(hash) == string(rootDigest) {
 				continue // already added
 			}
-			n, err := addExpirable(ctx, s.providerStore, hash, provider)
-			if err != nil {
-				return written, err
-			}
-			written += n
+			jq.Queue(ctx, digestProviderJob{hash, provider})
 		}
 	}
-	return written, nil
+
+	err := jq.Shutdown(ctx)
+	if err != nil {
+		return written, err
+	}
+
+	return written, jobErr
 }
 
 func addExpirable(ctx context.Context, providerStore types.ProviderStore, digest multihash.Multihash, provider model.ProviderResult) (uint64, error) {


### PR DESCRIPTION
This PR alters the provider cacher code to concurrently cache provider records up to 5 at a time.

In manual testing with an atrificial network delay I was able to see caching 10k provider records reduce from 20s to around 5s.

The aim is to process the caching queue faster as it is continually growing atm.