### PR TITLE
feat: expire caching queue indexes

### DIFF
--- a/cmd/lambda/providercache/main.go
+++ b/cmd/lambda/providercache/main.go
@@ -59,12 +59,6 @@ func makeHandler(cfg aws.Config) any {
 			go func(msg events.SQSMessage) {
 				defer wg.Done()
 				err := handleMessage(ctx, sqsCachingDecoder, providerCacher, msg)
-				if err == nil {
-					err := sqsCachingDecoder.CleanupMessage(ctx, msg.Body)
-					if err != nil {
-						log.Warnf("unable to cleanup message fully: %s", err.Error())
-					}
-				}
 				results <- handlerResult{msg.MessageId, err}
 			}(msg)
 		}

--- a/deploy/app/s3.tf
+++ b/deploy/app/s3.tf
@@ -2,6 +2,17 @@ resource "aws_s3_bucket" "caching_bucket" {
   bucket = "${terraform.workspace}-${var.app}-caching-bucket"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "caching_lifecycle" {
+  bucket = aws_s3_bucket.caching_bucket.id
+  rule {
+    id     = "${terraform.workspace}-${var.app}-caching-bucket-expire-all-rule"
+    status = "Enabled"
+    expiration {
+      days = 14
+    }
+  }
+}
+
 resource "aws_s3_bucket" "ipni_store_bucket" {
   bucket = "${terraform.workspace}-${var.app}-ipni-store-bucket"
 }

--- a/pkg/aws/sqscachingqueue.go
+++ b/pkg/aws/sqscachingqueue.go
@@ -133,17 +133,3 @@ func (s *SQSCachingDecoder) DecodeMessage(ctx context.Context, messageBody strin
 	}
 	return providercacher.ProviderCachingJob{Provider: msg.Provider, Index: index}, nil
 }
-
-// CleanupMessage removes stored information in the s3 bucket
-func (s *SQSCachingDecoder) CleanupMessage(ctx context.Context, messageBody string) error {
-	var msg CachingQueueMessage
-	err := json.Unmarshal([]byte(messageBody), &msg)
-	if err != nil {
-		return fmt.Errorf("deserializing message: %w", err)
-	}
-	_, err = s.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(s.bucket),
-		Key:    aws.String(msg.JobID.String()),
-	})
-	return err
-}


### PR DESCRIPTION
resolves https://github.com/storacha/indexing-service/issues/160

* Lifecycle rule removes indexes from bucket after 2 weeks.
* Should be faster (do not have to wait for delete operation).
* Should be cheaper (zero delete requests - and lifecycle rules are not charged).