### PR TITLE
chore(dns): alternate domain for API gateway, main domain for cloudfront

### DIFF
--- a/deploy/app/gateway.tf
+++ b/deploy/app/gateway.tf
@@ -1,5 +1,5 @@
 locals {
-    domain_name = terraform.workspace == "prod" ? "${var.app}.storacha.network" : "${terraform.workspace}.${var.app}.storacha.network"
+    domain_name = terraform.workspace == "prod" ? "api.${var.app}.storacha.network" : "${terraform.workspace}.${var.app}.storacha.network"
 }
 
 resource "aws_apigatewayv2_api" "api" {
@@ -111,6 +111,7 @@ resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = aws_acm_certificate.cert.arn
   validation_record_fqdns = [ aws_route53_record.cert_validation.fqdn ]
 }
+
 resource "aws_apigatewayv2_domain_name" "custom_domain" {
   domain_name = local.domain_name
 
@@ -120,6 +121,7 @@ resource "aws_apigatewayv2_domain_name" "custom_domain" {
     security_policy = "TLS_1_2"
   }
 }
+
 resource "aws_apigatewayv2_stage" "stage" {
   api_id = aws_apigatewayv2_api.api.id
   name   = "$default"
@@ -138,8 +140,8 @@ resource "aws_route53_record" "api_gateway" {
   type    = "A"
 
   alias {
-    name                   = terraform.workspace == "prod" ? aws_cloudfront_distribution.indexer[0].domain_name : aws_apigatewayv2_domain_name.custom_domain.domain_name_configuration[0].target_domain_name
-    zone_id                = terraform.workspace == "prod" ? aws_cloudfront_distribution.indexer[0].hosted_zone_id : aws_apigatewayv2_domain_name.custom_domain.domain_name_configuration[0].hosted_zone_id
+    name                   = aws_apigatewayv2_domain_name.custom_domain.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.custom_domain.domain_name_configuration[0].hosted_zone_id
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
For prod, we want the main `indexer.storacha.network` domain to point to the cloudfront distribution. The current config uses that domain name both as a custom domain for API gateway and as an alternate domain for the cloudfront distribution.

Instead of that, we will give the API gateway its own `api.indexer.storacha.network` domain to make it clearer which resource is using which domain name. This allows removing references to the gateway's custom domain in cloudfront route53 records, and references to the cloudfront domain in the gateway's config.