### PR TITLE
chore(infra): create a cloudfront distribution for staging too

### DIFF
--- a/deploy/app/cloudfront.tf
+++ b/deploy/app/cloudfront.tf
@@ -1,7 +1,7 @@
 locals {
-  # Only prod gets a CloudFront distribution
-  should_create_cloudfront = terraform.workspace == "prod"
-  cloudfront_alternate_domain = "${var.app}.storacha.network"
+  # Only prod and staging get a CloudFront distribution
+  should_create_cloudfront = terraform.workspace == "prod" || terraform.workspace == "staging"
+  cloudfront_alternate_domain = terraform.workspace == "prod" ? "${var.app}.storacha.network" : "${terraform.workspace}.${var.app}.storacha.network"
 }
 
 resource "aws_cloudfront_distribution" "indexer" {

--- a/deploy/app/gateway.tf
+++ b/deploy/app/gateway.tf
@@ -1,5 +1,5 @@
 locals {
-    domain_name = terraform.workspace == "prod" ? "api.${var.app}.storacha.network" : "${terraform.workspace}.${var.app}.storacha.network"
+    domain_name = terraform.workspace == "prod" ? "api.${var.app}.storacha.network" : (terraform.workspace == "staging" ? "api.staging.${var.app}.storacha.network" : "${terraform.workspace}.${var.app}.storacha.network")
 }
 
 resource "aws_apigatewayv2_api" "api" {


### PR DESCRIPTION
It is desirable for our staging environment to be as similar to the production one as possible. Taking a look at CloudFront pricing, it looks like we'll only be charged for the usage, so adding a distribution to the staging env won't be costly.