### PR TITLE
perf(lambda): up memory to 1GB for prod

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -66,7 +66,7 @@ resource "aws_lambda_function" "lambda" {
   architectures = [ "arm64" ]
   role          = aws_iam_role.lambda_exec.arn
   timeout          = try(each.value.timeout, 30)
-  memory_size      = try(each.value.memory_size, 128)
+  memory_size      = try(each.value.memory_size, terraform.workspace == "prod" ? 1024 : 128)
   reserved_concurrent_executions = try(each.value.concurrency, -1)
   source_code_hash = data.archive_file.function_archive[each.key].output_base64sha256
   filename      = data.archive_file.function_archive[each.key].output_path # Path to your Lambda zip files


### PR DESCRIPTION
# Goals

Speed up lambda executions -- we're giving the indexer currently only 1/8 the memory we give content claims. Importantly, CPU in Lambda is a function of memory, meaning we give it less than 1/8 the compute power.

# Implementation

Up to 1GB for prod like content claims