### PR TITLE
fix(telemetry): introduce sample ratio

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -119,6 +119,7 @@ resource "aws_lambda_function" "lambda" {
         HONEYCOMB_OTLP_ENDPOINT = "api.honeycomb.io:443"
         HONEYCOMB_API_KEY = "${var.honeycomb_api_key}"
         PRINCIPAL_MAPPING = var.principal_mapping
+        BASE_TRACE_SAMPLE_RATIO = terraform.workspace == "prod" ? "0.0001" : "1.0"
     }
   }
 

--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -55,6 +55,15 @@ func mustGetInt(envVar string) int64 {
 	return value
 }
 
+func mustGetFloat(envVar string) float64 {
+	stringValue := mustGetEnv(envVar)
+	value, err := strconv.ParseFloat(stringValue, 64)
+	if err != nil {
+		panic(fmt.Errorf("parsing env var %s to int: %w", envVar, err))
+	}
+	return value
+}
+
 // Config describes all the values required to setup AWS from the environment
 type Config struct {
 	construct.ServiceConfig
@@ -79,6 +88,7 @@ type Config struct {
 	LegacyBlockIndexTableName         string
 	LegacyBlockIndexTableRegion       string
 	LegacyDataBucketURL               string
+	BaseTraceSampleRatio              float64
 	HoneycombAPIKey                   string
 	PrincipalMapping                  map[string]string
 	principal.Signer
@@ -208,6 +218,7 @@ func FromEnv(ctx context.Context) Config {
 		LegacyBlockIndexTableName:         mustGetEnv("LEGACY_BLOCK_INDEX_TABLE_NAME"),
 		LegacyBlockIndexTableRegion:       mustGetEnv("LEGACY_BLOCK_INDEX_TABLE_REGION"),
 		LegacyDataBucketURL:               mustGetEnv("LEGACY_DATA_BUCKET_URL"),
+		BaseTraceSampleRatio:              mustGetFloat("BASE_TRACE_SAMPLE_RATIO"),
 		HoneycombAPIKey:                   os.Getenv("HONEYCOMB_API_KEY"),
 		PrincipalMapping:                  principalMapping,
 	}


### PR DESCRIPTION
# Goals

We're once again overconsuming our capacity on Honeycomb, cause while we're limiting spans to those with a parent on API calls, now that the provider caching job is working, we're recording tons of child span interactions with redis
![Screenshot 2025-03-28 at 5 57 11 PM](https://github.com/user-attachments/assets/c153b6f5-2f93-48ce-b4d6-f31ec704347f)

# Implementation

for spans that have no parent, introduce a sampling ratio, to prevent overloading honeycomb.