### PR TITLE
fix(aws): fix caching queue for non-fifo

### DIFF
--- a/pkg/aws/sqscachingqueue.go
+++ b/pkg/aws/sqscachingqueue.go
@@ -86,9 +86,8 @@ func (s *SQSCachingQueue) sendMessage(ctx context.Context, msg CachingQueueMessa
 		return fmt.Errorf("serializing message json: %w", err)
 	}
 	_, err = s.sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
-		QueueUrl:       aws.String(s.queueURL),
-		MessageBody:    aws.String(string(messageJSON)),
-		MessageGroupId: aws.String("default"),
+		QueueUrl:    aws.String(s.queueURL),
+		MessageBody: aws.String(string(messageJSON)),
 	})
 	if err != nil {
 		return fmt.Errorf("enqueueing message: %w", err)


### PR DESCRIPTION
# Goals

Apparently setting a MessageGroupID is not allowed on a non-FIFO queue, which is causing event delivery to fail

# Implementation

- Remove MessageGroupID