### PR TITLE
fix(cbor-gen): use larger value for arrays in blobindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ apply: deploy/app/.terraform .tfworkspace lambdas
 mockery:
 	mockery --config=.mockery.yaml
 
-.PHONY: serde
+pkg/blobindex/datamodel/shardeddagindex_cbor_gen.go: pkg/blobindex/datamodel/shardeddagindex.go
+	go run ./scripts/cbor_gen.go
 
-serde:
-	go generate ./...
+serde: pkg/blobindex/datamodel/shardeddagindex_cbor_gen.go

--- a/pkg/blobindex/datamodel/shardeddagindex.go
+++ b/pkg/blobindex/datamodel/shardeddagindex.go
@@ -32,8 +32,6 @@ func BlobIndexSchema() schema.Type {
 	return shardedTs.TypeByName("BlobIndex")
 }
 
-//go:generate cbor-gen-for PositionModel BlobSliceModel BlobIndexModel
-
 // ShardedDagIndexModel is the golang structure for encoding sharded DAG index header blocks
 type ShardedDagIndexModel struct {
 	DagO_1 *ShardedDagIndexModel_0_1

--- a/pkg/blobindex/datamodel/shardeddagindex_cbor_gen.go
+++ b/pkg/blobindex/datamodel/shardeddagindex_cbor_gen.go
@@ -220,7 +220,7 @@ func (t *BlobIndexModel) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Slices ([]datamodeltype.BlobSliceModel) (slice)
-	if len(t.Slices) > 8192 {
+	if len(t.Slices) > 131072 {
 		return xerrors.Errorf("Slice value in field t.Slices was too long")
 	}
 
@@ -288,7 +288,7 @@ func (t *BlobIndexModel) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 8192 {
+	if extra > 131072 {
 		return fmt.Errorf("t.Slices: array too large (%d)", extra)
 	}
 

--- a/scripts/cbor_gen.go
+++ b/scripts/cbor_gen.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	blobindex "github.com/storacha/indexing-service/pkg/blobindex/datamodel"
+	cborgen "github.com/whyrusleeping/cbor-gen"
+)
+
+func runCborGen() error {
+	genName, err := filepath.Abs("./pkg/blobindex/datamodel/shardeddagindex_cbor_gen.go")
+	if err != nil {
+		return err
+	}
+	return cborgen.Gen{
+		MaxArrayLength:  2 << 16, // Maximum length for arrays = 131072
+		MaxByteLength:   2 << 20, // Maximum length for byte slices
+		MaxStringLength: 2 << 20, // Maximum length for strings
+	}.WriteTupleEncodersToFile(genName, "datamodeltype", blobindex.PositionModel{}, blobindex.BlobSliceModel{}, blobindex.BlobIndexModel{})
+}
+
+func main() {
+	fmt.Print("Generating Cbor Marshal/Unmarshal...")
+
+	if err := runCborGen(); err != nil {
+		fmt.Println("Failed: ")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Println("Done.")
+}


### PR DESCRIPTION
# Goals

Support realistically size blob indexes by increasing cbor-gen's max slice length

# Implementation

Needed to create a manual script for cbor-gen to pass a custom array size unfortunately.

Set to 131072 for now
