### PR TITLE
fix: increase timeout to 5m for POST /claims

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -11,6 +11,7 @@ locals {
     }
     postclaims = {
       name = "POSTclaims"
+      timeout = 300
     }
     notifier = {
       name = "notifier"


### PR DESCRIPTION
Tentatively increases the timeout for the `POST /claims` handler to 5 minutes. Invoking `assert/index` with indexes that have 10k+ items can take a long time to cache.

I'm not sure we really want to wait for all this...