### PR TITLE
feat(redisstore): add multiwrite operation

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -62,9 +62,17 @@ type Cache[Key, Value any] interface {
 	Get(ctx context.Context, key Key) (Value, error)
 }
 
+type MultiOperation[Value any] interface {
+	Add(values ...Value)
+	SetExpirable(expires bool)
+}
+
+type ProviderMultiOperation = MultiOperation[model.ProviderResult]
+
 // ValueSetCache describes a cache interface whose values are sets
 type ValueSetCache[Key, Value any] interface {
 	Add(ctx context.Context, key Key, values ...Value) (uint64, error)
+	Multi(ctx context.Context, keys []Key, operation func(MultiOperation[Value])) (uint64, error)
 	SetExpirable(ctx context.Context, key Key, expires bool) error
 	Members(ctx context.Context, key Key) ([]Value, error)
 }


### PR DESCRIPTION
# Goals

In case serialization is a source of slowness, a quick fix for that to enable operations on multiple redis keys at once

# Implementation

Put jobqueue logic inside the store

Might look at redis transactions instead anyway :)