### PR TITLE
feat(providerindex): don't hang on IPNI timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.2 // indirect
 	github.com/aws/smithy-go v1.22.1 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/containerd v1.7.27 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.37.8
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.2
 	github.com/awslabs/aws-lambda-go-api-proxy v0.16.2
+	github.com/benbjohnson/clock v1.3.5
 	github.com/google/uuid v1.6.0
 	github.com/ipfs/go-cid v0.5.0
 	github.com/ipfs/go-datastore v0.6.0
@@ -69,7 +70,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.2 // indirect
 	github.com/aws/smithy-go v1.22.1 // indirect
-	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/containerd v1.7.27 // indirect

--- a/pkg/service/providerindex/providerindex_test.go
+++ b/pkg/service/providerindex/providerindex_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/ipni/go-libipni/find/model"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/ipnipublisher/publisher"
 	"github.com/storacha/go-libstoracha/metadata"
+	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/indexing-service/pkg/internal/testutil"
 	"github.com/storacha/indexing-service/pkg/internal/testutil/extmocks"
 	"github.com/storacha/indexing-service/pkg/types"
@@ -500,6 +502,55 @@ func TestGetProviderResults(t *testing.T) {
 		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
 
 		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
+		require.NoError(t, err)
+		require.Equal(t, []model.ProviderResult{expectedResult}, results)
+	})
+	t.Run("legacy returns valid result and IPNI hangs", func(t *testing.T) {
+		mockStore := types.NewMockProviderStore(t)
+		mockNoProviderStore := types.NewMockNoProviderStore(t)
+		mockIpniFinder := extmocks.NewMockIpniFinder(t)
+		mockIpniPublisher := extmocks.NewMockIpniPublisher(t)
+		mockLegacyClaims := NewMockLegacyClaimsFinder(t)
+		clock := clock.NewMock()
+		providerIndex := NewWithClock(mockStore, mockNoProviderStore, mockIpniFinder, mockIpniPublisher, mockLegacyClaims, clock)
+
+		someHash := testutil.RandomMultihash()
+		expectedResult := testutil.RandomLocationCommitmentProviderResult()
+		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
+
+		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		// IPNI returns an error.
+		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).RunAndReturn(func(ctx context.Context, _ multihash.Multihash) (*model.FindResponse, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		})
+
+		// Legacy returns a valid result.
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return([]model.ProviderResult{expectedResult}, nil)
+		// Expect caching of the legacy result.
+		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
+		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
+
+		resultChan := make(chan result.Result[[]model.ProviderResult, error], 1)
+		go func() {
+			resultChan <- result.Wrap(func() ([]model.ProviderResult, error) {
+				return providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
+			})
+		}()
+
+		clock.Add(IPNITimeout / 2)
+		select {
+		case <-resultChan:
+			t.Fatal("should not yet have a result until IPNI context is cancelled")
+		default:
+		}
+
+		// after timeout result should be available with IPNI context cancelled
+		clock.Add(IPNITimeout)
+		results, err := result.Unwrap(<-resultChan)
 		require.NoError(t, err)
 		require.Equal(t, []model.ProviderResult{expectedResult}, results)
 	})

--- a/pkg/service/providerindex/providerindex_test.go
+++ b/pkg/service/providerindex/providerindex_test.go
@@ -522,10 +522,8 @@ func TestGetProviderResults(t *testing.T) {
 		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		// IPNI returns an error.
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).RunAndReturn(func(ctx context.Context, _ multihash.Multihash) (*model.FindResponse, error) {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
+			<-ctx.Done()
+			return nil, ctx.Err()
 		})
 
 		// Legacy returns a valid result.


### PR DESCRIPTION
# Goals

We're getting a number of 500s when IPNI hangs indefinitely, eventually causing lambdas to timeout.

# Implementation

when IPNI queries hang (which happens frequently), don't get stuck till lambda timesout -- limit wait to 1.5 seconds
- add timeout to context before querying with IPNI
- inject clock library for time testing (this is temporary till synctest lands in default golang build -- it's in 1.24 but not default build)
- add test to verify behavior