### PR TITLE
fix: increase cache queue concurrency

### DIFF
--- a/pkg/service/providerindex/providerindex.go
+++ b/pkg/service/providerindex/providerindex.go
@@ -327,7 +327,7 @@ func Cache(ctx context.Context, providerStore types.ProviderStore, provider peer
 		jobqueue.JobHandler(func(ctx context.Context, digest mh.Multihash) error {
 			return addProviderResult(ctx, providerStore, digest, pr, expire)
 		}),
-		jobqueue.WithConcurrency(5),
+		jobqueue.WithConcurrency(500),
 		jobqueue.WithErrorHandler(func(err error) { joberr = err }),
 	)
 	q.Startup()


### PR DESCRIPTION
re: https://github.com/storacha/indexing-service/pull/200#pullrequestreview-2822538569

Goroutines are cheap, let see if simply increasing job concurrency will be fast enough.