### PR TITLE
feat: add `GET /.well-known/did.json` route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LAMBDA_GOARCH=arm64
 LAMBDA_GOCC?=go
 LAMBDA_GOFLAGS=-tags=lambda.norpc -ldflags="-s -w -X github.com/storacha/indexing-service/pkg/build.version=$(VERSION)"
 LAMBDA_CGO_ENABLED=0
-LAMBDADIRS=build/getclaim build/getclaims build/getroot build/notifier build/postclaims build/providercache build/remotesync
+LAMBDADIRS=build/getclaim build/getclaims build/getdiddocument build/getroot build/notifier build/postclaims build/providercache build/remotesync
 LAMBDAS=$(foreach dir, $(LAMBDADIRS), $(dir)/bootstrap)
 OTELCOL_CONFIG=otel-collector-config.yaml
 

--- a/cmd/lambda/getdiddocument/main.go
+++ b/cmd/lambda/getdiddocument/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
+	"github.com/storacha/indexing-service/cmd/lambda"
+	"github.com/storacha/indexing-service/pkg/aws"
+	"github.com/storacha/indexing-service/pkg/server"
+)
+
+func main() {
+	lambda.Start(makeHandler)
+}
+
+func makeHandler(cfg aws.Config) any {
+	handler := httpadapter.NewV2(server.GetDIDDocument(cfg.Signer)).ProxyWithContext
+	return handler
+}

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -9,6 +9,9 @@ locals {
     getclaims = {
       name = "GETclaims"
     }
+    getdiddocument = {
+      name = "GETdiddocument"
+    }
     postclaims = {
       name = "POSTclaims"
       timeout = 300

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -235,8 +235,6 @@ func GetClaimsHandler(service types.Querier) http.HandlerFunc {
 
 // Document is a did document that describes a did subject.
 // See https://www.w3.org/TR/did-core/#dfn-did-documents.
-// TODO: Should we include the non-standard publicKey field for compatability reasons?
-// See https://w3c.github.io/did-spec-registries/#publickey
 type Document struct {
 	Context            []string             `json:"@context"` // https://w3id.org/did/v1
 	ID                 string               `json:"id"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -89,6 +90,7 @@ func NewServer(indexer types.Service, opts ...Option) *http.ServeMux {
 	mux.HandleFunc("GET /claim/{claim}", GetClaimHandler(indexer))
 	mux.HandleFunc("POST /claims", PostClaimsHandler(c.id, indexer, c.contentClaimsOptions...))
 	mux.HandleFunc("GET /claims", GetClaimsHandler(indexer))
+	mux.HandleFunc("GET /.well-known/did.json", GetDIDDocument(c.id))
 	return mux
 }
 
@@ -228,5 +230,58 @@ func GetClaimsHandler(service types.Querier) http.HandlerFunc {
 		if err != nil {
 			log.Errorf("sending claims response: %w", err)
 		}
+	}
+}
+
+// Document is a did document that describes a did subject.
+// See https://www.w3.org/TR/did-core/#dfn-did-documents.
+// TODO: Should we include the non-standard publicKey field for compatability reasons?
+// See https://w3c.github.io/did-spec-registries/#publickey
+type Document struct {
+	Context            []string             `json:"@context"` // https://w3id.org/did/v1
+	ID                 string               `json:"id"`
+	Controller         []string             `json:"controller,omitempty"`
+	VerificationMethod []VerificationMethod `json:"verificationMethod,omitempty"`
+	Authentication     []string             `json:"authentication,omitempty"`
+	AssertionMethod    []string             `json:"assertionMethod,omitempty"`
+}
+
+// VerificationMethod describes how to authenticate or authorize interactions
+// with a did subject.
+// See https://www.w3.org/TR/did-core/#dfn-verification-method.
+type VerificationMethod struct {
+	ID                 string `json:"id,omitempty"`
+	Type               string `json:"type,omitempty"`
+	Controller         string `json:"controller,omitempty"`
+	PublicKeyMultibase string `json:"publicKeyMultibase,omitempty"`
+}
+
+// GetDIDDocument returns the DID document for did:web resolution.
+func GetDIDDocument(id principal.Signer) http.HandlerFunc {
+	doc := Document{
+		Context: []string{"https://w3id.org/did/v1"},
+		ID:      id.DID().String(),
+	}
+	if s, ok := id.(signer.WrappedSigner); ok {
+		vid := fmt.Sprintf("%s#owner", id.DID())
+		doc.VerificationMethod = []VerificationMethod{
+			{
+				ID:                 vid,
+				Type:               "Ed25519VerificationKey2020",
+				Controller:         id.DID().String(),
+				PublicKeyMultibase: strings.TrimPrefix(s.Unwrap().DID().String(), "did:key:"),
+			},
+		}
+		doc.Authentication = []string{vid}
+		doc.AssertionMethod = []string{vid}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		bytes, err := json.Marshal(doc)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		w.Write(bytes)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -261,12 +261,12 @@ func GetDIDDocument(id principal.Signer) http.HandlerFunc {
 		ID:      id.DID().String(),
 	}
 	if s, ok := id.(signer.WrappedSigner); ok {
-		vid := fmt.Sprintf("%s#owner", id.DID())
+		vid := fmt.Sprintf("%s#owner", s.DID())
 		doc.VerificationMethod = []VerificationMethod{
 			{
 				ID:                 vid,
 				Type:               "Ed25519VerificationKey2020",
-				Controller:         id.DID().String(),
+				Controller:         s.DID().String(),
 				PublicKeyMultibase: strings.TrimPrefix(s.Unwrap().DID().String(), "did:key:"),
 			},
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -335,6 +335,6 @@ func TestGetDIDDocumentHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, doc.ID, didweb.DID().String())
-		require.True(t, strings.HasSuffix(testutil.Service.DID().String(), doc.VerificationMethod[0].PublicKeyMultibase))
+		require.Equal(t, strings.TrimPrefix(testutil.Service.DID().String(), "did:key:"), doc.VerificationMethod[0].PublicKeyMultibase)
 	})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -299,6 +299,7 @@ func TestGetDIDDocumentHandler(t *testing.T) {
 
 		res, err := http.Get(svr.URL)
 		require.NoError(t, err)
+		defer res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
 
 		bytes, err := io.ReadAll(res.Body)
@@ -323,6 +324,7 @@ func TestGetDIDDocumentHandler(t *testing.T) {
 
 		res, err := http.Get(svr.URL)
 		require.NoError(t, err)
+		defer res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
 
 		bytes, err := io.ReadAll(res.Body)
@@ -333,5 +335,6 @@ func TestGetDIDDocumentHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, doc.ID, didweb.DID().String())
+		require.True(t, strings.HasSuffix(testutil.Service.DID().String(), doc.VerificationMethod[0].PublicKeyMultibase))
 	})
 }


### PR DESCRIPTION
Serve a DID document like the following at `/.well-known/did.json`. It allows external entities to resolve and verify our `did:web`:

```json
{
  "@context": "https://w3id.org/did/v1",
  "id": "did:web:indexer.storacha.network",
  "verificationMethod": [
    {
      "id": "did:web:indexer.storacha.network#owner",
      "type": "Ed25519VerificationKey2020",
      "controller": "did:web:indexer.storacha.network",
      "publicKeyMultibase": "z6MknTPdpBGfFysJWCJn7SbhrAA7Xmp6ZCnjH9dPxJy2T7sk"
    }
  ],
  "assertionMethod": [
    "did:web:indexer.storacha.network#owner"
  ],
  "authentication": [
    "did:web:indexer.storacha.network#owner"
  ]
}
```