### PR TITLE
feat(providerindex): use no-providers with IPNI only

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -59,6 +59,10 @@ data "aws_region" "block_index" {
   provider = aws.block_index
 }
 
+data "aws_region" "allocations" {
+  provider = aws.allocations
+}
+
 # Define functions
 resource "aws_lambda_function" "lambda" {
   depends_on = [ aws_cloudwatch_log_group.lambda_log_group ]
@@ -113,6 +117,8 @@ resource "aws_lambda_function" "lambda" {
         LEGACY_CLAIMS_TABLE_NAME = data.aws_dynamodb_table.legacy_claims_table.id
         LEGACY_CLAIMS_TABLE_REGION = data.aws_region.legacy_claims.name
         LEGACY_CLAIMS_BUCKET_NAME = data.aws_s3_bucket.legacy_claims_bucket.id
+        LEGACY_ALLOCATIONS_TABLE_NAME = data.aws_dynamodb_table.legacy_allocations_table.id
+        LEGACY_ALLOCATIONS_TABLE_REGION = data.aws_region.allocations.name
         LEGACY_BLOCK_INDEX_TABLE_NAME = data.aws_dynamodb_table.legacy_block_index_table.id
         LEGACY_BLOCK_INDEX_TABLE_REGION = data.aws_region.block_index.name
         LEGACY_DATA_BUCKET_URL = var.legacy_data_bucket_url != "" ? var.legacy_data_bucket_url : "https://carpark-${terraform.workspace == "prod" ? "prod" : "staging"}-0.r2.w3s.link"

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -32,13 +32,13 @@ variable "legacy_block_index_table_region" {
 
 
 variable "legacy_allocations_table_name" {
-  description = "The name of the legacy block index DynamoDB table"
+  description = "The name of the legacy w3infra allocations DynamoDB table"
   type = string
   default = ""
 }
 
 variable "legacy_allocations_table_region" {
-  description = "The region where the legacy block index DynamoDB table is provisioned"
+  description = "The region where the legacy w3infra allocations DynamoDB table is provisioned"
   type = string
   default = ""
 }

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -37,7 +37,6 @@ variable "legacy_allocations_table_name" {
   default = ""
 }
 
-# the block index table is always deployed in us-west-2 for both prod and staging
 variable "legacy_allocations_table_region" {
   description = "The region where the legacy block index DynamoDB table is provisioned"
   type = string

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -32,13 +32,13 @@ variable "legacy_block_index_table_region" {
 
 
 variable "legacy_allocations_table_name" {
-  description = "The name of the legacy w3infra allocations DynamoDB table"
+  description = "The name of the legacy w3infra allocation DynamoDB table"
   type = string
   default = ""
 }
 
 variable "legacy_allocations_table_region" {
-  description = "The region where the legacy w3infra allocations DynamoDB table is provisioned"
+  description = "The region where the legacy w3infra allocation DynamoDB table is provisioned"
   type = string
   default = ""
 }

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -29,11 +29,28 @@ variable "legacy_block_index_table_region" {
   default = "us-west-2"
 }
 
+
+
+variable "legacy_allocations_table_name" {
+  description = "The name of the legacy block index DynamoDB table"
+  type = string
+  default = ""
+}
+
+# the block index table is always deployed in us-west-2 for both prod and staging
+variable "legacy_allocations_table_region" {
+  description = "The region where the legacy block index DynamoDB table is provisioned"
+  type = string
+  default = ""
+}
+
 locals {
     inferred_legacy_claims_table_name = var.legacy_claims_table_name != "" ? var.legacy_claims_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-content-claims-claims-v1"
     inferred_legacy_claims_table_region = var.legacy_claims_table_region != "" ? var.legacy_claims_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
     inferred_legacy_claims_bucket_name = var.legacy_claims_bucket_name != "" ? var.legacy_claims_bucket_name : "${terraform.workspace == "prod" ? "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8" : "staging-content-claims-buc-claimsv1bucketefd46802-1xx2brszve6t3"}"
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
+    inferred_legacy_allocations_table_name = var.legacy_allocations_table_name != "" ? var.legacy_allocations_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-allocation"
+    inferred_legacy_allocations_table_region = var.legacy_allocations_table_region != "" ? var.legacy_allocations_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
 }
 
 provider "aws" {
@@ -61,6 +78,18 @@ data "aws_dynamodb_table" "legacy_block_index_table" {
   name = local.inferred_legacy_block_index_table_name
 }
 
+
+provider "aws" {
+  alias = "allocations"
+  region = local.inferred_legacy_allocations_table_region
+}
+
+
+data "aws_dynamodb_table" "legacy_allocations_table" {
+  provider = aws.allocations
+  name = local.inferred_legacy_allocations_table_name
+}
+
 data "aws_iam_policy_document" "lambda_legacy_dynamodb_query_document" {
   statement {
     actions = [
@@ -68,7 +97,9 @@ data "aws_iam_policy_document" "lambda_legacy_dynamodb_query_document" {
     ]
     resources = [
       data.aws_dynamodb_table.legacy_claims_table.arn,
-      data.aws_dynamodb_table.legacy_block_index_table.arn
+      data.aws_dynamodb_table.legacy_block_index_table.arn,
+      data.aws_dynamodb_table.legacy_allocations_table.arn,
+      "${data.aws_dynamodb_table.legacy_allocations_table.arn}/index/*",
     ]
   }
 }

--- a/pkg/aws/dynamoallocationstable.go
+++ b/pkg/aws/dynamoallocationstable.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	multihash "github.com/multiformats/go-multihash"
+	"github.com/storacha/indexing-service/pkg/internal/digestutil"
+)
+
+type DynamoAllocationsTable struct {
+	client    dynamodb.QueryAPIClient
+	tableName string
+}
+
+func (d *DynamoAllocationsTable) Has(ctx context.Context, digest multihash.Multihash) (bool, error) {
+	digestAttr, err := attributevalue.Marshal(digestutil.Format(digest))
+	if err != nil {
+		return false, err
+	}
+
+	keyEx := expression.Key("multihash").Equal(expression.Value(digestAttr))
+	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+	if err != nil {
+		return false, err
+	}
+
+	result, err := d.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String(d.tableName),
+		IndexName:                 aws.String("multihash"),
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		KeyConditionExpression:    expr.KeyCondition(),
+		Select:                    types.SelectCount,
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return result.Count > 0, nil
+}
+
+func NewDynamoAllocationsTable(client dynamodb.QueryAPIClient, tableName string) *DynamoAllocationsTable {
+	return &DynamoAllocationsTable{client, tableName}
+}

--- a/pkg/aws/dynamoallocationstable_test.go
+++ b/pkg/aws/dynamoallocationstable_test.go
@@ -1,0 +1,185 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/storacha/indexing-service/pkg/internal/digestutil"
+	"github.com/storacha/indexing-service/pkg/internal/link"
+	"github.com/storacha/indexing-service/pkg/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamoAllocationsTable(t *testing.T) {
+	if os.Getenv("CI") != "" && runtime.GOOS != "linux" {
+		t.SkipNow()
+	}
+
+	ctx := context.Background()
+	endpoint := createDynamo(t)
+	dynamoClient := newDynamoClient(t, endpoint)
+
+	tableName := "prod-w3infra-allocations"
+	createAllocationsTable(t, dynamoClient, tableName)
+
+	t.Run("query existing item", func(t *testing.T) {
+		digest := testutil.RandomMultihash()
+		insertedAt := time.Now().String()
+		space := testutil.RandomPrincipal().DID().String()
+		invocation := testutil.RandomCID().String()
+		size := "123"
+		_, err := dynamoClient.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]types.AttributeValue{
+				"multihash":  &types.AttributeValueMemberS{Value: digestutil.Format(digest)},
+				"space":      &types.AttributeValueMemberS{Value: space},
+				"size":       &types.AttributeValueMemberN{Value: size},
+				"invocation": &types.AttributeValueMemberS{Value: invocation},
+				"insertedAt": &types.AttributeValueMemberS{Value: insertedAt},
+			},
+		})
+		require.NoError(t, err)
+
+		store := NewDynamoAllocationsTable(dynamoClient, tableName)
+
+		has, err := store.Has(ctx, digest)
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+
+	t.Run("query multiple existing items for same digest", func(t *testing.T) {
+		root := testutil.RandomCID()
+		digest := link.ToCID(root).Hash()
+
+		items := []struct {
+			space      string
+			size       string
+			invocation string
+			insertedAt string
+		}{
+			{
+				space:      testutil.RandomPrincipal().DID().String(),
+				size:       fmt.Sprintf("%d", rand.IntN(1024*1024*128)),
+				invocation: testutil.RandomCID().String(),
+				insertedAt: time.Now().AddDate(-1, 0, 0).String(),
+			},
+			{
+				space:      testutil.RandomPrincipal().DID().String(),
+				size:       fmt.Sprintf("%d", rand.IntN(1024*1024*128)),
+				invocation: testutil.RandomCID().String(),
+				insertedAt: time.Now().String(),
+			},
+		}
+
+		for _, i := range items {
+			_, err := dynamoClient.PutItem(ctx, &dynamodb.PutItemInput{
+				TableName: aws.String(tableName),
+				Item: map[string]types.AttributeValue{
+					"multihash":  &types.AttributeValueMemberS{Value: digestutil.Format(digest)},
+					"space":      &types.AttributeValueMemberS{Value: i.space},
+					"size":       &types.AttributeValueMemberN{Value: i.size},
+					"invocation": &types.AttributeValueMemberS{Value: i.invocation},
+					"insertedAt": &types.AttributeValueMemberS{Value: i.insertedAt},
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		store := NewDynamoAllocationsTable(dynamoClient, tableName)
+
+		has, err := store.Has(ctx, digest)
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+
+	t.Run("query not found", func(t *testing.T) {
+		digest := testutil.RandomMultihash()
+		store := NewDynamoAllocationsTable(dynamoClient, tableName)
+		has, err := store.Has(ctx, digest)
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+}
+
+func createAllocationsTable(t *testing.T, c *dynamodb.Client, tableName string) {
+	_, err := c.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName:   aws.String(tableName),
+		BillingMode: types.BillingModePayPerRequest,
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("space"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("multihash"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("size"),
+				AttributeType: types.ScalarAttributeTypeN,
+			},
+			{
+				AttributeName: aws.String("invocation"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("insertedAt"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("space"),
+				KeyType:       types.KeyTypeHash,
+			},
+			{
+				AttributeName: aws.String("multihash"),
+				KeyType:       types.KeyTypeRange,
+			},
+		},
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("multihash"),
+				KeySchema: []types.KeySchemaElement{
+					{
+						AttributeName: aws.String("multihash"),
+						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("space"),
+						KeyType:       types.KeyTypeRange,
+					},
+				},
+				Projection: &types.Projection{
+					NonKeyAttributes: []string{"space", "insertedAt"},
+					ProjectionType:   types.ProjectionTypeInclude,
+				},
+			},
+			{
+				IndexName: aws.String("insertedAt"),
+				KeySchema: []types.KeySchemaElement{
+					{
+						AttributeName: aws.String("insertedAt"),
+						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("space"),
+						KeyType:       types.KeyTypeRange,
+					},
+				},
+				Projection: &types.Projection{
+					ProjectionType: types.ProjectionTypeAll,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+}

--- a/pkg/service/providerindex/providerindex_test.go
+++ b/pkg/service/providerindex/providerindex_test.go
@@ -94,6 +94,7 @@ func TestGetProviderResults(t *testing.T) {
 		targetClaim := []multicodec.Code{metadata.LocationCommitmentID}
 
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
+		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return(nil, nil)
 		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(targetClaim, nil)
 
 		results, err := providerIndex.getProviderResults(context.Background(), someHash, targetClaim)
@@ -187,6 +188,8 @@ func TestGetProviderResults(t *testing.T) {
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(&model.FindResponse{}, nil)
+		mockNoProviderStore.EXPECT().Add(testutil.AnyContext, someHash, multicodec.Code(metadata.LocationCommitmentID)).Return(1, nil)
+		mockNoProviderStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
 		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, []multicodec.Code{metadata.LocationCommitmentID}).Return([]model.ProviderResult{expectedResult}, nil)
 		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
 		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
@@ -221,6 +224,8 @@ func TestGetProviderResults(t *testing.T) {
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(ipniFinderResponse, nil)
+		mockNoProviderStore.EXPECT().Add(testutil.AnyContext, someHash, multicodec.Code(metadata.LocationCommitmentID)).Return(1, nil)
+		mockNoProviderStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
 		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, []multicodec.Code{metadata.LocationCommitmentID}).Return([]model.ProviderResult{expectedResult}, nil)
 		mockStore.EXPECT().Add(testutil.AnyContext, someHash, expectedResult).Return(1, nil)
 		mockStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
@@ -308,6 +313,8 @@ func TestGetProviderResults(t *testing.T) {
 		mockStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(&model.FindResponse{}, nil)
+		mockNoProviderStore.EXPECT().Add(testutil.AnyContext, someHash, multicodec.Code(0)).Return(1, nil)
+		mockNoProviderStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
 		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, []multicodec.Code{0}).Return(nil, errors.New("some error"))
 
 		_, err := providerIndex.getProviderResults(context.Background(), someHash, []multicodec.Code{0})
@@ -495,6 +502,8 @@ func TestGetProviderResults(t *testing.T) {
 		mockNoProviderStore.EXPECT().Members(testutil.AnyContext, someHash).Return(nil, types.ErrKeyNotFound)
 		// IPNI returns an error.
 		mockIpniFinder.EXPECT().Find(testutil.AnyContext, someHash).Return(&model.FindResponse{}, nil)
+		mockNoProviderStore.EXPECT().Add(testutil.AnyContext, someHash, multicodec.Code(metadata.LocationCommitmentID)).Return(1, nil)
+		mockNoProviderStore.EXPECT().SetExpirable(testutil.AnyContext, someHash, true).Return(nil)
 		// Legacy returns a valid result.
 		mockLegacyClaims.EXPECT().Find(testutil.AnyContext, someHash, targetClaim).Return([]model.ProviderResult{expectedResult}, nil)
 		// Expect caching of the legacy result.


### PR DESCRIPTION
# Goals

Fix our caching issues with IPNI and store protocol

# Implementation

- the basic approach here is to have the no-providers cache ONLY apply to IPNI queries
   - changes are in ProviderIndex moving no-providers reads+write to inside the IPNI query
- this neccesitates one additional optimization:
   - the slow step child for legacy queries is the fallback mapper, which actually does a head request on an R2 bucket
   - the optimization introduced is to check the allocations db table first -- if it's not there, no need for a potential cross region request to R2
   
# For Discussion

Changes to the indexer are.... tricky. We may need to figure out a long term solution here to get to more rapidly deployable solutions & potentially blue/green deployments