### PR TITLE
feat: configure IPNI endpoint and announce URLs

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -15,3 +15,7 @@ TF_VAR_did=
 # TF_VAR_legacy_claims_table_name=
 # TF_VAR_legacy_claims_table_region=
 # TF_VAR_legacy_data_bucket_url=
+
+# optional - IPNI configuration
+# TF_VAR_ipni_endpoint=
+# TF_VAR_ipni_announce_urls=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
       workspace: staging
       did: did:web:staging.indexer.storacha.network
       apply: ${{ github.event_name != 'pull_request' }}
+      ipni-endpoint: ${{ vars.STAGING_IPNI_ENDPOINT }}
+      ipni-announce-urls: ${{ vars.STAGING_IPNI_ANNOUNCE_URLS }}
     secrets:
       aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
       aws-region: ${{ secrets.STAGING_AWS_REGION }}
@@ -46,6 +48,8 @@ jobs:
       workspace: prod
       did: did:web:indexer.storacha.network
       apply: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+      ipni-endpoint: ${{ vars.PROD_IPNI_ENDPOINT }}
+      ipni-announce-urls: ${{ vars.PROD_IPNI_ANNOUNCE_URLS }}
     secrets:
       aws-account-id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ secrets.PROD_AWS_REGION }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,6 +15,12 @@ on:
       apply:
         required: true
         type: boolean
+      ipni-endpoint:
+        required: false
+        type: string
+      ipni-announce-urls:
+        required: false
+        type: string
     secrets:
       aws-account-id:
         required: true
@@ -37,6 +43,8 @@ env:
   TF_VAR_private_key: ${{ secrets.private-key }}
   TF_VAR_did: ${{ inputs.did }}
   TF_VAR_honeycomb_api_key: ${{ secrets.honeycomb-api-key }}
+  TF_VAR_ipni_endpoint: ${{ inputs.ipni-endpoint }}
+  TF_VAR_ipni_announce_urls: ${{ inputs.ipni-announce-urls }}
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ Optional. JSON encoded mapping of did:web to did:key. e.g.
 TF_VAR_principal_mapping={"did:web:example.com":"did:key:z6MktkCXwNmpqejQxYd7JHPcw7d4Srjct7sX74VLfKqsPyAw"}
 ```
 
+#### `TF_VAR_ipni_endpoint`
+
+Optional. HTTP endpoint of the IPNI instance used to discover providers.
+
+```sh
+TF_VAR_ipni_endpoint="https://cid.contact"
+```
+
+#### `TF_VAR_ipni_announce_urls`
+
+Optional. JSON array of IPNI node URLs to announce chain updates to.
+
+```sh
+TF_VAR_ipni_announce_urls=["https://cid.contact/announce"]
+```
+
 ### Deployment commands
 
 Note that these commands will call needed prerequisites -- `make apply` will essentially do all of these start to finish.

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -101,7 +101,8 @@ resource "aws_lambda_function" "lambda" {
         CLAIMS_REDIS_CACHE = local.claims_cache.id
         CLAIMS_CACHE_EXPIRATION_SECONDS = "${terraform.workspace == "prod" ? 7 * 24 * 60 * 60 : 24 * 60 * 60}"
         REDIS_USER_ID = local.cache_iam_user.user_id
-        IPNI_ENDPOINT = "https://cid.contact"
+        IPNI_ENDPOINT = var.ipni_endpoint
+        IPNI_ANNOUNCE_URLS = var.ipni_announce_urls
         PROVIDER_CACHING_QUEUE_URL = aws_sqs_queue.caching.id
         PROVIDER_CACHING_BUCKET_NAME = aws_s3_bucket.caching_bucket.bucket
         CHUNK_LINKS_TABLE_NAME = aws_dynamodb_table.chunk_links.id

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -37,3 +37,15 @@ variable "legacy_data_bucket_url" {
   description = "URL to use when constructing synthesizing legacy claims"
   default = ""
 }
+
+variable "ipni_endpoint" {
+  type        = string
+  description = "Optional HTTP endpoint of the IPNI instance used to discover providers."
+  default     = "https://cid.contact"
+}
+
+variable "ipni_announce_urls" {
+  type        = string
+  description = "Optional JSON array of IPNI node URLs to announce chain updates to."
+  default     = "[\"https://cid.contact/announce\"]"
+}

--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -78,6 +78,7 @@ type Config struct {
 	MetadataTableName                 string
 	IPNIStoreBucket                   string
 	IPNIStorePrefix                   string
+	IPNIAnnounceURLs                  []url.URL
 	NotifierHeadBucket                string
 	NotifierTopicArn                  string
 	ClaimStoreBucket                  string
@@ -155,6 +156,16 @@ func FromEnv(ctx context.Context) Config {
 		principalMapping = presets.PrincipalMapping
 	}
 
+	var ipniPublisherDirectAnnounceURLs []string
+	if os.Getenv("IPNI_ANNOUNCE_URLS") != "" {
+		err := json.Unmarshal([]byte(os.Getenv("IPNI_ANNOUNCE_URLS")), &ipniPublisherDirectAnnounceURLs)
+		if err != nil {
+			panic(fmt.Errorf("parsing IPNI announce URLs JSON: %w", err))
+		}
+	} else {
+		ipniPublisherDirectAnnounceURLs = presets.IPNIAnnounceURLs
+	}
+
 	return Config{
 		Config: awsConfig,
 		Signer: id,
@@ -197,8 +208,9 @@ func FromEnv(ctx context.Context) Config {
 					MinVersion: tls.VersionTLS12,
 				},
 			},
-			IndexerURL:             mustGetEnv("IPNI_ENDPOINT"),
-			PublisherAnnounceAddrs: []string{ipniPublisherAnnounceAddress},
+			IndexerURL:                  mustGetEnv("IPNI_ENDPOINT"),
+			PublisherAnnounceAddrs:      []string{ipniPublisherAnnounceAddress},
+			PublisherDirectAnnounceURLs: ipniPublisherDirectAnnounceURLs,
 		},
 		ProvidersCacheExpirationSeconds:   mustGetInt("PROVIDERS_CACHE_EXPIRATION_SECONDS"),
 		NoProvidersCacheExpirationSeconds: mustGetInt("NO_PROVIDERS_CACHE_EXPIRATION_SECONDS"),

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -1,5 +1,7 @@
 package presets
 
+var IPNIAnnounceURLs = []string{"https://cid.contact/announce"}
+
 var PrincipalMapping = map[string]string{
 	"did:web:staging.up.storacha.network": "did:key:z6MkhcbEpJpEvNVDd3n5RurquVdqs5dPU16JDU5VZTDtFgnn",
 	"did:web:up.storacha.network":         "did:key:z6MkqdncRZ1wj8zxCTDUQ8CRT8NQWd63T7mZRvZUX8B7XDFi",


### PR DESCRIPTION
Allows the IPNI endpoint for queries to be configured so that when we have deployed our own IPNI instance we can use it for querying.

Allows the IPNI announce URLs to be configured so that when we have deployed our own IPNI instance we can announce to it as well as cid.contact.