### PR TITLE
fix: equals claim content lookup

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -184,7 +184,12 @@ func (is *IndexingService) jobHandler(mhCtx context.Context, j job, spawn func(j
 					}
 				} else {
 					// lookup was the equals hash, queue the content hash
-					if err := spawn(job{multihash.Multihash(result.ContextID), nil, nil, types.QueryTypeLocation}); err != nil {
+					contentCid, err := cid.Cast(result.ContextID)
+					if err != nil {
+						telemetry.Error(s, err, "decoding context ID as CID")
+						return err
+					}
+					if err := spawn(job{contentCid.Hash(), nil, nil, types.QueryTypeLocation}); err != nil {
 						telemetry.Error(s, err, "queuing job for content hash")
 						return err
 					}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -184,12 +184,7 @@ func (is *IndexingService) jobHandler(mhCtx context.Context, j job, spawn func(j
 					}
 				} else {
 					// lookup was the equals hash, queue the content hash
-					contentCid, err := cid.Cast(result.ContextID)
-					if err != nil {
-						telemetry.Error(s, err, "decoding context ID as CID")
-						return err
-					}
-					if err := spawn(job{contentCid.Hash(), nil, nil, types.QueryTypeLocation}); err != nil {
+					if err := spawn(job{multihash.Multihash(result.ContextID), nil, nil, types.QueryTypeLocation}); err != nil {
 						telemetry.Error(s, err, "queuing job for content hash")
 						return err
 					}
@@ -494,7 +489,7 @@ func publishEqualsClaim(ctx context.Context, claims contentclaims.Service, provI
 	var digests []multihash.Multihash
 	digests = append(digests, nb.Content.Hash())
 	digests = append(digests, nb.Equals.(cidlink.Link).Cid.Hash())
-	contextID := nb.Equals.Binary()
+	contextID := string(nb.Content.Hash())
 	err = provIndex.Publish(ctx, provider, contextID, slices.Values(digests), meta)
 	if err != nil {
 		return fmt.Errorf("publishing equals claim: %w", err)


### PR DESCRIPTION
The context ID when publishing an equals claim needs to be the content hash not the equals hash.

This is because if we query for the equals hash we try to get a location claim for the content:
https://github.com/storacha/indexing-service/blob/ebd51266fdfbfcb230d5620dca81634a070558cc/pkg/service/service.go#L185-L191

## Details

When querying the indexer for a piece CID `bafkzcibdr4dqnpio7ck6dniyyslw22qkhkoxzzy7v52plrotzibt2hwvdeya6uaw` an equals claim is expected to be returned, giving us the shard CID.

Currently, we are casting a binary CID as a multihash and using that to query IPNI, which is failing with the error:

```console
ERROR    indexer/find    find/server.go:189    find: input is not a valid base58 or hex encoded multihash    
{
    "multihash": "4r21cAhd3V8t3kHeP4PZpm9s9E3RoBaJ3V6Kd2LmquRnHwJaCvJUHK",
    "err": "length greater than remaining number of bytes in buffer",
    "hexErr": "encoding/hex: invalid byte: U+0072 'r'"
}
```

The cause is [this line](https://github.com/storacha/indexing-service/blob/ebd51266fdfbfcb230d5620dca81634a070558cc/pkg/service/service.go#L187) where we cast the context ID as a multihash, which ends up being passed to IPNI in the URL: https://staging.ipni.storacha.network/multihash/4r21cAhd3V8t3kHeP4PZpm9s9E3RoBaJ3V6Kd2LmquRnHwJaCvJUHK

When publishing an equals claim, we know that we set the context ID to the equivalent CID (which is the piece CID usually):
https://github.com/storacha/indexing-service/blob/ebd51266fdfbfcb230d5620dca81634a070558cc/pkg/service/service.go#L492

Therefore if we decode `4r21cAhd3V8t3kHeP4PZpm9s9E3RoBaJ3V6Kd2LmquRnHwJaCvJUHK` we should get the original piece CID:

```go
c, err := cid.Parse("z4r21cAhd3V8t3kHeP4PZpm9s9E3RoBaJ3V6Kd2LmquRnHwJaCvJUHK")
fmt.Println(c.StringOfBase(multibase.Base32))
// bafkzcibdr4dqnpio7ck6dniyyslw22qkhkoxzzy7v52plrotzibt2hwvdeya6uaw <nil>
```

So, instead of encoding the equivalent CID in the context ID we should encode the content multihash.

