### PR TITLE
fix: use the right shared state

### DIFF
--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 # access state for shared resources (primary DNS zone, dev VPC and dev caches)
 data "terraform_remote_state" "shared" {
   backend = "s3"
-  workspace = terraform.workspace
+  workspace = local.is_warm ? terraform.workspace : "default"
   config = {
     bucket = "storacha-terraform-state"
     key    = "storacha/indexing-service/shared.tfstate"

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -33,6 +33,7 @@ provider "aws" {
 # access state for shared resources (primary DNS zone, dev VPC and dev caches)
 data "terraform_remote_state" "shared" {
   backend = "s3"
+  workspace = terraform.workspace
   config = {
     bucket = "storacha-terraform-state"
     key    = "storacha/indexing-service/shared.tfstate"

--- a/deploy/shared/outputs.tf
+++ b/deploy/shared/outputs.tf
@@ -3,20 +3,20 @@ output "primary_zone" {
 }
 
 output "dev_vpc" {
-  value = {
+  value = length(module.dev_vpc) > 0 ? {
     id = module.dev_vpc[0].id
     cidr_block = module.dev_vpc[0].cidr_block
     subnet_ids = module.dev_vpc[0].subnet_ids
-  }
+  } : null
 }
 
 output "dev_caches" {
-  value = {
+  value = length(module.dev_caches) > 0 ? {
     providers = module.dev_caches[0].providers
     no_providers = module.dev_caches[0].no_providers
     indexes = module.dev_caches[0].indexes
     claims = module.dev_caches[0].claims
     iam_user = module.dev_caches[0].iam_user
     security_group_id = module.dev_caches[0].security_group_id
-  }
+  } : null
 }


### PR DESCRIPTION
The `terraform_remote_state` data resource doesn't fetch the remote state corresponding to the workspace in use unless it is explicitly said to do so, which is a bit surprising IMO. Now that not all workspaces actually share exactly the same shared resources, the distinction is important.

This is a hack to fix CI, but it's not a definitive solution. I think we shouldn't be using workspaces with shared state because the goal of workspaces is precisely to isolate instances of state data. Instead, we should always use the `default` workspace and differentiate by network.