### PR TITLE
fix: content CID is not a shard CID

### DIFF
--- a/pkg/service/providerindex/legacy.go
+++ b/pkg/service/providerindex/legacy.go
@@ -201,7 +201,6 @@ func (ls LegacyClaimsStore) synthetizeLocationProviderResult(caveats assert.Loca
 		encodedCtxID = contextID
 	}
 
-	contentCid := cid.NewCidV1(cid.Raw, caveats.Content.Hash())
 	var rng *metadata.Range
 	if caveats.Range != nil {
 		rng = &metadata.Range{
@@ -210,7 +209,6 @@ func (ls LegacyClaimsStore) synthetizeLocationProviderResult(caveats assert.Loca
 		}
 	}
 	meta := metadata.LocationCommitmentMetadata{
-		Shard:      &contentCid,
 		Range:      rng,
 		Expiration: expiration,
 		Claim:      claimCid,

--- a/pkg/service/providerindex/legacy_test.go
+++ b/pkg/service/providerindex/legacy_test.go
@@ -176,7 +176,7 @@ func TestSynthetizeProviderResult(t *testing.T) {
 		md := metadata.MetadataContext.New()
 		require.NoError(t, md.UnmarshalBinary(result.Metadata))
 		locMeta := md.Get(metadata.LocationCommitmentID).(*metadata.LocationCommitmentMetadata)
-		require.Equal(t, contentCid, *locMeta.Shard)
+		require.Nil(t, locMeta.Shard)
 		require.Nil(t, locMeta.Range)
 		require.Equal(t, int64(*locationDelegation.Expiration()), locMeta.Expiration)
 		require.Equal(t, link.ToCID(locationDelegation.Link()), locMeta.Claim)


### PR DESCRIPTION
While debugging the indexing service cache I found this error. I'm not 100% certain I understand what this field is for in the metadata but it is not for the DAG root CID.