### PR TITLE
fix: limit results from legacy block index table

### DIFF
--- a/pkg/aws/dynamoblockindextable.go
+++ b/pkg/aws/dynamoblockindextable.go
@@ -13,6 +13,12 @@ import (
 	"github.com/storacha/indexing-service/pkg/types"
 )
 
+// Some blocks are in MANY CARs. The limit here is set to the same limit that
+// was previously applied in the legacy content claims service when fetching
+// items from this same table.
+// https://github.com/storacha/content-claims/blob/d837231389d60fa50c3d36b421bf3062cc7350ce/packages/infra/src/lib/store/block-index.js#L16C7-L16C12
+const limit = 25
+
 type DynamoProviderBlockIndexTable struct {
 	client    dynamodb.QueryAPIClient
 	tableName string
@@ -44,6 +50,7 @@ func (d *DynamoProviderBlockIndexTable) Query(ctx context.Context, digest multih
 		ExpressionAttributeValues: expr.Values(),
 		KeyConditionExpression:    expr.KeyCondition(),
 		ProjectionExpression:      expr.Projection(),
+		Limit:                     aws.Int32(limit),
 	})
 
 	for queryPaginator.HasMorePages() {


### PR DESCRIPTION
Some blocks are in MANY MANY CARs - sometimes because it's a popular block (`LICENCE.md` for example) and other times we had a bug that meant that the same content got uploaded many times over in different CAR files.

This PR adds a limit of 25 to the legacy block index table query results. The same value that is used in the legacy content claims service.

It prevents the indexing service from using too much cache space for a given hash and ensures quick response times in cases where a block is found in many CARs.