### PR TITLE
fix: hot and warm network route53 zone conflicts

### DIFF
--- a/deploy/app/cloudfront.tf
+++ b/deploy/app/cloudfront.tf
@@ -78,7 +78,7 @@ resource "aws_route53_record" "cloudfront_cert_validation" {
   allow_overwrite = true
   name    = tolist(aws_acm_certificate.cloudfront_cert[0].domain_validation_options)[0].resource_record_name
   type    = tolist(aws_acm_certificate.cloudfront_cert[0].domain_validation_options)[0].resource_record_type
-  zone_id = data.terraform_remote_state.shared.outputs.primary_zone.zone_id
+  zone_id = local.dns_zone_id
   records = [tolist(aws_acm_certificate.cloudfront_cert[0].domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }

--- a/deploy/app/gateway.tf
+++ b/deploy/app/gateway.tf
@@ -1,5 +1,4 @@
 locals {
-  is_warm = startswith(terraform.workspace, "warm-")
   network = local.is_warm ? "warm.storacha.network" : "storacha.network"
   domain_base = "${var.app}.${local.network}"
   domain_name = local.is_production ? local.domain_base : local.is_staging ? "staging.${local.domain_base}" : "${terraform.workspace}.${local.domain_base}"
@@ -124,7 +123,7 @@ resource "aws_route53_record" "cert_validation" {
   allow_overwrite = true
   name    = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_name
   type    = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_type
-  zone_id = data.terraform_remote_state.shared.outputs.primary_zone.zone_id
+  zone_id = local.dns_zone_id
   records = [tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
@@ -155,7 +154,7 @@ resource "aws_apigatewayv2_api_mapping" "api_mapping" {
 }
 
 resource "aws_route53_record" "api_gateway" {
-  zone_id = data.terraform_remote_state.shared.outputs.primary_zone.zone_id
+  zone_id = local.dns_zone_id
   name    = aws_apigatewayv2_domain_name.custom_domain.domain_name
   type    = "A"
 

--- a/deploy/app/locals.tf
+++ b/deploy/app/locals.tf
@@ -1,4 +1,7 @@
 locals {
     is_production = terraform.workspace == "prod" || terraform.workspace == "warm-prod"
     is_staging = terraform.workspace == "staging" || terraform.workspace == "warm-staging"
+    is_warm = startswith(terraform.workspace, "warm-")
+
+    dns_zone_id = local.is_warm ? data.terraform_remote_state.shared.outputs.warm_zone.zone_id : data.terraform_remote_state.shared.outputs.hot_zone.zone_id
 }

--- a/deploy/shared/locals.tf
+++ b/deploy/shared/locals.tf
@@ -1,7 +1,4 @@
 locals {
   is_production = terraform.workspace == "prod" || terraform.workspace == "warm-prod"
   is_staging = terraform.workspace == "staging" || terraform.workspace == "warm-staging"
-
-  is_warm = startswith(terraform.workspace, "warm-")
-  network = local.is_warm ? "warm.storacha.network" : "storacha.network"
 }

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -26,6 +26,24 @@ provider "aws" {
   }
 }
 
-resource "aws_route53_zone" "primary" {
-  name = "${var.app}.${local.network}"
+removed {
+  from = aws_route53_zone.primary
+}
+
+import {
+  to = aws_route53_zone.hot
+  id = "Z069841432CRU732HASNL"
+}
+
+resource "aws_route53_zone" "hot" {
+  name = "${var.app}.storacha.network"
+}
+
+import {
+  to = aws_route53_zone.warm
+  id = "Z0845167J9GR7IUCNBTW"
+}
+
+resource "aws_route53_zone" "warm" {
+  name = "${var.app}.warm.storacha.network"
 }

--- a/deploy/shared/outputs.tf
+++ b/deploy/shared/outputs.tf
@@ -1,5 +1,9 @@
-output "primary_zone" {
-  value = aws_route53_zone.primary
+output "hot_zone" {
+  value = aws_route53_zone.hot
+}
+
+output "warm_zone" {
+  value = aws_route53_zone.warm
 }
 
 output "dev_vpc" {


### PR DESCRIPTION
Adding different networks introduces different "levels of sharedness" to shared resources. Some of them are truly shared amongst all envs no matter what network they serve, while others are shared by envs within the same network.

This specifically applies to the Route53 hosted zone. I thought a single resource could be shared but that's not how it works. This PR adds another zone for the warm network.

I checked the plans in CI and things look good. No unexpected changes to prod or staging, but certs and validations records fixed for warm-staging.