### PR TITLE
feat(aws): skip unmigrated dotstorage shards

### DIFF
--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -130,6 +130,7 @@ resource "aws_lambda_function" "lambda" {
         LEGACY_ALLOCATIONS_TABLE_REGION = data.aws_region.allocations.name
         LEGACY_BLOCK_INDEX_TABLE_NAME = data.aws_dynamodb_table.legacy_block_index_table.id
         LEGACY_BLOCK_INDEX_TABLE_REGION = data.aws_region.block_index.name
+        LEGACY_DOT_STORAGE_BUCKET_PREFIXES = join(",", var.legacy_dotstorage_bucket_prefixes != [] ? var.legacy_dotstorage_bucket_prefixes : terraform.workspace == "prod" ? ["us-west-2/dotstorage-prod-1", "us-east-2/dotstorage-prod-0"] : ["us-east-2/dotstorage-staging-0"])
         LEGACY_STORE_TABLE_NAME = data.aws_dynamodb_table.legacy_store_table.name
         LEGACY_STORE_TABLE_REGION = data.aws_region.store.name
         LEGACY_BLOB_REGISTRY_TABLE_NAME = data.aws_dynamodb_table.legacy_blob_registry_table.name

--- a/deploy/app/lambda.tf
+++ b/deploy/app/lambda.tf
@@ -59,6 +59,14 @@ data "aws_region" "block_index" {
   provider = aws.block_index
 }
 
+data "aws_region" "store" {
+  provider = aws.store
+}
+
+data "aws_region" "blob_registry" {
+  provider = aws.blob_registry
+}
+
 data "aws_region" "allocations" {
   provider = aws.allocations
 }
@@ -122,6 +130,10 @@ resource "aws_lambda_function" "lambda" {
         LEGACY_ALLOCATIONS_TABLE_REGION = data.aws_region.allocations.name
         LEGACY_BLOCK_INDEX_TABLE_NAME = data.aws_dynamodb_table.legacy_block_index_table.id
         LEGACY_BLOCK_INDEX_TABLE_REGION = data.aws_region.block_index.name
+        LEGACY_STORE_TABLE_NAME = data.aws_dynamodb_table.legacy_store_table.name
+        LEGACY_STORE_TABLE_REGION = data.aws_region.store.name
+        LEGACY_BLOB_REGISTRY_TABLE_NAME = data.aws_dynamodb_table.legacy_blob_registry_table.name
+        LEGACY_BLOB_REGISTRY_TABLE_REGION = data.aws_region.blob_registry.name
         LEGACY_DATA_BUCKET_URL = var.legacy_data_bucket_url != "" ? var.legacy_data_bucket_url : "https://carpark-${terraform.workspace == "prod" ? "prod" : "staging"}-0.r2.w3s.link"
         GOLOG_LOG_LEVEL = local.is_production ? "error" : "debug"
         OTEL_PROPAGATORS = "tracecontext"

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -30,6 +30,31 @@ variable "legacy_block_index_table_region" {
 }
 
 
+variable "legacy_store_table_name" {
+  description = "The name of the legacy store DynamoDB table"
+  type = string
+  default = ""
+}
+
+# the store table is always deployed in us-west-2 for both prod and staging
+variable "legacy_store_table_region" {
+  description = "The region where the legacy store DynamoDB table is provisioned"
+  type = string
+  default = "us-west-2"
+}
+
+variable "legacy_blob_registry_table_name" {
+  description = "The name of the legacy blob registry table DynamoDB table"
+  type = string
+  default = ""
+}
+
+# the blob registry table is always deployed in us-west-2 for both prod and staging
+variable "legacy_blob_registry_table_region" {
+  description = "The region where the legacy blob registry table DynamoDB table is provisioned"
+  type = string
+  default = "us-west-2"
+}
 
 variable "legacy_allocations_table_name" {
   description = "The name of the legacy w3infra allocation DynamoDB table"
@@ -48,6 +73,8 @@ locals {
     inferred_legacy_claims_table_region = var.legacy_claims_table_region != "" ? var.legacy_claims_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
     inferred_legacy_claims_bucket_name = var.legacy_claims_bucket_name != "" ? var.legacy_claims_bucket_name : "${terraform.workspace == "prod" ? "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8" : "staging-content-claims-buc-claimsv1bucketefd46802-1xx2brszve6t3"}"
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
+    inferred_legacy_store_table_name = var.legacy_store_table_name != "" ? var.legacy_store_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-store"
+    inferred_legacy_blob_registry_table_name = var.legacy_blob_registry_table_name != "" ? var.legacy_blob_registry_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-blob-registry"
     inferred_legacy_allocations_table_name = var.legacy_allocations_table_name != "" ? var.legacy_allocations_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-allocation"
     inferred_legacy_allocations_table_region = var.legacy_allocations_table_region != "" ? var.legacy_allocations_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
 }
@@ -77,6 +104,25 @@ data "aws_dynamodb_table" "legacy_block_index_table" {
   name = local.inferred_legacy_block_index_table_name
 }
 
+provider "aws" {
+  alias = "store"
+  region = var.legacy_store_table_region
+}
+
+data "aws_dynamodb_table" "legacy_store_table" {
+  provider = aws.store
+  name = local.inferred_legacy_store_table_name
+}
+
+provider "aws" {
+  alias = "blob_registry"
+  region = var.legacy_blob_registry_table_region
+}
+
+data "aws_dynamodb_table" "legacy_blob_registry_table" {
+  provider = aws.blob_registry
+  name = local.inferred_legacy_blob_registry_table_name
+}
 
 provider "aws" {
   alias = "allocations"

--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -29,6 +29,11 @@ variable "legacy_block_index_table_region" {
   default = "us-west-2"
 }
 
+variable "legacy_dotstorage_bucket_prefixes" {
+  description = "list of prefixes for the legacy dotstorage buckets"
+  type = list(string)
+  default = []
+}
 
 variable "legacy_store_table_name" {
   description = "The name of the legacy store DynamoDB table"
@@ -36,11 +41,10 @@ variable "legacy_store_table_name" {
   default = ""
 }
 
-# the store table is always deployed in us-west-2 for both prod and staging
 variable "legacy_store_table_region" {
   description = "The region where the legacy store DynamoDB table is provisioned"
   type = string
-  default = "us-west-2"
+  default = ""
 }
 
 variable "legacy_blob_registry_table_name" {
@@ -49,11 +53,10 @@ variable "legacy_blob_registry_table_name" {
   default = ""
 }
 
-# the blob registry table is always deployed in us-west-2 for both prod and staging
 variable "legacy_blob_registry_table_region" {
   description = "The region where the legacy blob registry table DynamoDB table is provisioned"
   type = string
-  default = "us-west-2"
+  default = ""
 }
 
 variable "legacy_allocations_table_name" {
@@ -74,7 +77,9 @@ locals {
     inferred_legacy_claims_bucket_name = var.legacy_claims_bucket_name != "" ? var.legacy_claims_bucket_name : "${terraform.workspace == "prod" ? "prod-content-claims-bucket-claimsv1bucketefd46802-1mqz6d8o7xw8" : "staging-content-claims-buc-claimsv1bucketefd46802-1xx2brszve6t3"}"
     inferred_legacy_block_index_table_name = var.legacy_block_index_table_name != "" ? var.legacy_block_index_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-ep-v1-blocks-cars-position"
     inferred_legacy_store_table_name = var.legacy_store_table_name != "" ? var.legacy_store_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-store"
+    inferred_legacy_store_table_region = var.legacy_store_table_region != "" ? var.legacy_store_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
     inferred_legacy_blob_registry_table_name = var.legacy_blob_registry_table_name != "" ? var.legacy_blob_registry_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-blob-registry"
+    inferred_legacy_blob_registry_table_region = var.legacy_blob_registry_table_region != "" ? var.legacy_blob_registry_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
     inferred_legacy_allocations_table_name = var.legacy_allocations_table_name != "" ? var.legacy_allocations_table_name : "${terraform.workspace == "prod" ? "prod" : "staging"}-w3infra-allocation"
     inferred_legacy_allocations_table_region = var.legacy_allocations_table_region != "" ? var.legacy_allocations_table_region : "${terraform.workspace == "prod" ? "us-west-2" : "us-east-2"}"
 }
@@ -106,7 +111,7 @@ data "aws_dynamodb_table" "legacy_block_index_table" {
 
 provider "aws" {
   alias = "store"
-  region = var.legacy_store_table_region
+  region = local.inferred_legacy_store_table_region
 }
 
 data "aws_dynamodb_table" "legacy_store_table" {
@@ -116,7 +121,7 @@ data "aws_dynamodb_table" "legacy_store_table" {
 
 provider "aws" {
   alias = "blob_registry"
-  region = var.legacy_blob_registry_table_region
+  region = local.inferred_legacy_blob_registry_table_region
 }
 
 data "aws_dynamodb_table" "legacy_blob_registry_table" {

--- a/pkg/aws/blockindextablemapper.go
+++ b/pkg/aws/blockindextablemapper.go
@@ -160,9 +160,6 @@ func isLegacyDotStorage(parts []string, bucketPrefixes []string) bool {
 		return false
 	}
 	for _, prefix := range bucketPrefixes {
-		fmt.Println(strings.Join(parts, "/"))
-		fmt.Println(prefix)
-		fmt.Println(strings.Join(parts[:2], "/") == prefix && !strings.Contains(parts[4], "nft-"))
 		if strings.Join(parts[:2], "/") == prefix && !strings.Contains(parts[4], "nft-") {
 			return true
 		}

--- a/pkg/aws/blockindextablemapper_test.go
+++ b/pkg/aws/blockindextablemapper_test.go
@@ -2,13 +2,18 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/multiformats/go-multihash"
 	cassert "github.com/storacha/go-libstoracha/capabilities/assert"
 	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/indexing-service/pkg/bytemap"
 	"github.com/storacha/indexing-service/pkg/internal/digestutil"
 	"github.com/storacha/indexing-service/pkg/internal/testutil"
@@ -21,9 +26,11 @@ func TestBlockIndexTableMapper(t *testing.T) {
 	bucketURL := testutil.Must(url.Parse("https://test.bucket.example.com"))(t)
 
 	fixtures := []struct {
-		name   string
-		digest multihash.Multihash
-		record BlockIndexRecord
+		name                string
+		digest              multihash.Multihash
+		record              BlockIndexRecord
+		migratedShardCheck  ipld.Link
+		migratedShardResult result.Result[bool, error]
 		// the expected location URL in the materlized claim
 		expectedURL *url.URL
 		// signals that no claim can be materialized from fixture
@@ -33,11 +40,36 @@ func TestBlockIndexTableMapper(t *testing.T) {
 			name:   "b32 multihash key",
 			digest: testutil.Must(digestutil.Parse("zQmNUfyG3ynAkCzPFLsijsJwEFpPXqJZF1CJpT9GLYmgBBd"))(t),
 			record: BlockIndexRecord{
-				CarPath: "us-west-2/dotstorage-prod-1/raw/bafyreifvbqc4e5qphijgpj43qxk5ndw2vbfbhkzuuuvpo4cturr2dfk45e/315318734258474846/ciqd7nsjnsrsi6pqulv5j46qel7gw6oeo644o5ef3zopne37xad5oui.car",
+				CarPath: "us-west-2/nftstorage-prod-1/raw/bafyreifvbqc4e5qphijgpj43qxk5ndw2vbfbhkzuuuvpo4cturr2dfk45e/315318734258474846/ciqd7nsjnsrsi6pqulv5j46qel7gw6oeo644o5ef3zopne37xad5oui.car",
 				Offset:  128844,
 				Length:  200,
 			},
 			expectedURL: bucketURL.JoinPath("/bagbaierah63es3fder47bixl2tz5aix6nn44i55zy52ilxs462jx7oah25iq/bagbaierah63es3fder47bixl2tz5aix6nn44i55zy52ilxs462jx7oah25iq.car"),
+		},
+		{
+			name:   "b32 multihash key, dot storage, migrated",
+			digest: testutil.Must(digestutil.Parse("zQmNUfyG3ynAkCzPFLsijsJwEFpPXqJZF1CJpT9GLYmgBBd"))(t),
+			record: BlockIndexRecord{
+				CarPath: "us-west-2/dotstorage-prod-1/raw/bafyreifvbqc4e5qphijgpj43qxk5ndw2vbfbhkzuuuvpo4cturr2dfk45e/315318734258474846/ciqd7nsjnsrsi6pqulv5j46qel7gw6oeo644o5ef3zopne37xad5oui.car",
+				Offset:  128844,
+				Length:  200,
+			},
+			migratedShardCheck:  cidlink.Link{Cid: testutil.Must(cid.Parse("bagbaierah63es3fder47bixl2tz5aix6nn44i55zy52ilxs462jx7oah25iq"))(t)},
+			migratedShardResult: result.Ok[bool, error](true),
+			expectedURL:         bucketURL.JoinPath("/bagbaierah63es3fder47bixl2tz5aix6nn44i55zy52ilxs462jx7oah25iq/bagbaierah63es3fder47bixl2tz5aix6nn44i55zy52ilxs462jx7oah25iq.car"),
+		},
+		{
+			name:   "b32 multihash key, dot storage, not migrated",
+			digest: testutil.Must(digestutil.Parse("zQmNUfyG3ynAkCzPFLsijsJwEFpPXqJZF1CJpT9GLYmgBBd"))(t),
+			record: BlockIndexRecord{
+				CarPath: "us-west-2/dotstorage-prod-1/raw/bafyreifvbqc4e5qphijgpj43qxk5ndw2vbfbhkzuuuvpo4cturr2dfk45e/315318734258474846/ciqd7nsjnsrsi6pqulv5j46qel7gw6oeo644o5ef3zopne37xad5oui.car",
+				Offset:  128844,
+				Length:  200,
+			},
+			migratedShardCheck:  cidlink.Link{Cid: testutil.Must(cid.Parse("bagbaierah63es3fder47bixl2tz5aix6nn44i55zy52ilxs462jx7oah25iq"))(t)},
+			migratedShardResult: result.Ok[bool, error](false),
+			expectedURL:         nil,
+			noClaim:             true,
 		},
 		{
 			name:   "b32 CAR CID key",
@@ -76,7 +108,11 @@ func TestBlockIndexTableMapper(t *testing.T) {
 		t.Run(f.name, func(t *testing.T) {
 			mockStore := newMockBlockIndexStore()
 			mockStore.data.Set(f.digest, []BlockIndexRecord{f.record})
-			bitMapper, err := NewBlockIndexTableMapper(id, mockStore, bucketURL.String(), time.Hour)
+			mockMigratedShardChecker := newMockMigratedShardChecker()
+			if f.migratedShardCheck != nil {
+				mockMigratedShardChecker.data[f.migratedShardCheck] = f.migratedShardResult
+			}
+			bitMapper, err := NewBlockIndexTableMapper(id, mockStore, mockMigratedShardChecker, bucketURL.String(), time.Hour)
 			require.NoError(t, err)
 
 			claimCids, err := bitMapper.GetClaims(context.Background(), f.digest)
@@ -111,7 +147,8 @@ func TestBlockIndexTableMapper(t *testing.T) {
 
 	t.Run("returns ErrKeyNotFound when block index errors with not found", func(t *testing.T) {
 		mockStore := newMockBlockIndexStore()
-		bitMapper, err := NewBlockIndexTableMapper(id, mockStore, bucketURL.String(), time.Hour)
+		mockMigratedShardChecker := newMockMigratedShardChecker()
+		bitMapper, err := NewBlockIndexTableMapper(id, mockStore, mockMigratedShardChecker, bucketURL.String(), time.Hour)
 		require.NoError(t, err)
 
 		_, err = bitMapper.GetClaims(context.Background(), testutil.RandomMultihash())
@@ -134,5 +171,23 @@ func (bs *mockBlockIndexStore) Query(ctx context.Context, digest multihash.Multi
 func newMockBlockIndexStore() *mockBlockIndexStore {
 	return &mockBlockIndexStore{
 		data: bytemap.NewByteMap[multihash.Multihash, []BlockIndexRecord](1),
+	}
+}
+
+type mockMigratedShardChecker struct {
+	data map[ipld.Link]result.Result[bool, error]
+}
+
+func (msc *mockMigratedShardChecker) ShardMigrated(ctx context.Context, shard ipld.Link) (bool, error) {
+	res, ok := msc.data[shard]
+	if !ok {
+		return false, errors.New("shard not found in mock checker")
+	}
+	return result.Unwrap(res)
+}
+
+func newMockMigratedShardChecker() *mockMigratedShardChecker {
+	return &mockMigratedShardChecker{
+		data: make(map[ipld.Link]result.Result[bool, error]),
 	}
 }

--- a/pkg/aws/dynamomigratedshardchecker.go
+++ b/pkg/aws/dynamomigratedshardchecker.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
+	dynamotypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+)
+
+type DynamoMigratedShardChecker struct {
+	storeTableClient        dynamodb.QueryAPIClient
+	blobRegistryTableClient dynamodb.QueryAPIClient
+	blobRegistryTableName   string
+	storeTableName          string
+}
+
+func (d *DynamoMigratedShardChecker) storeTableShardMigrated(ctx context.Context, shard ipld.Link) (bool, error) {
+
+	keyEx := expression.Key("link").Equal(expression.Value(shard.String()))
+	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+	if err != nil {
+		return false, err
+	}
+
+	o, err := d.storeTableClient.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String(d.storeTableName),
+		IndexName:                 aws.String("cid"),
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		KeyConditionExpression:    expr.KeyCondition(),
+		ProjectionExpression:      expr.Projection(),
+		Select:                    dynamotypes.SelectCount,
+	})
+	if err != nil {
+		return false, fmt.Errorf("querying store table: %w", err)
+	}
+	return o.Count > 0, nil
+}
+
+func (d *DynamoMigratedShardChecker) blobRegistryTableShardMigrated(ctx context.Context, shard ipld.Link) (bool, error) {
+	cl, ok := shard.(cidlink.Link)
+	if !ok {
+		return false, fmt.Errorf("shard is not a CID link: %T", shard)
+	}
+
+	keyEx := expression.Key("digest").Equal(expression.Value(cl.Cid.Hash().B58String()))
+	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+	if err != nil {
+		return false, err
+	}
+
+	o, err := d.blobRegistryTableClient.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String(d.blobRegistryTableName),
+		IndexName:                 aws.String("digest"),
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		KeyConditionExpression:    expr.KeyCondition(),
+		ProjectionExpression:      expr.Projection(),
+		Select:                    dynamotypes.SelectCount,
+	})
+	if err != nil {
+		return false, fmt.Errorf("querying store table: %w", err)
+	}
+	return o.Count > 0, nil
+}
+
+func (d *DynamoMigratedShardChecker) ShardMigrated(ctx context.Context, shard ipld.Link) (bool, error) {
+	if migrated, err := d.storeTableShardMigrated(ctx, shard); err != nil {
+		return false, err
+	} else if migrated {
+		return true, nil
+	}
+	return d.blobRegistryTableShardMigrated(ctx, shard)
+}
+
+func NewDynamoMigratedShardChecker(storeTableClient dynamodb.QueryAPIClient, blobRegistryTableClient dynamodb.QueryAPIClient, blobRegistryTableName, storeTableName string) *DynamoMigratedShardChecker {
+	return &DynamoMigratedShardChecker{
+		storeTableClient:        storeTableClient,
+		blobRegistryTableClient: blobRegistryTableClient,
+		blobRegistryTableName:   blobRegistryTableName,
+		storeTableName:          storeTableName,
+	}
+}

--- a/pkg/aws/dynamomigratedshardchecker_test.go
+++ b/pkg/aws/dynamomigratedshardchecker_test.go
@@ -1,0 +1,167 @@
+package aws
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/storacha/indexing-service/pkg/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamoMigratedShardChecker(t *testing.T) {
+	if os.Getenv("CI") != "" && runtime.GOOS != "linux" {
+		t.SkipNow()
+	}
+
+	ctx := context.Background()
+	endpoint := createDynamo(t)
+	dynamoClient := newDynamoClient(t, endpoint)
+
+	storeTable := "store-" + uuid.NewString()
+	blobRegistryTable := "blob-registry-" + uuid.NewString()
+	createStoreTable(t, dynamoClient, storeTable)
+	createBlobRegistryTable(t, dynamoClient, blobRegistryTable)
+	checker := NewDynamoMigratedShardChecker(dynamoClient, dynamoClient, blobRegistryTable, storeTable)
+
+	t.Run("exists in store table", func(t *testing.T) {
+
+		cid := testutil.RandomCID()
+		space := testutil.RandomPrincipal().DID()
+		_, err := dynamoClient.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(storeTable),
+			Item: map[string]types.AttributeValue{
+				"link":  &types.AttributeValueMemberS{Value: cid.String()},
+				"space": &types.AttributeValueMemberS{Value: space.DID().String()},
+			},
+		})
+		require.NoError(t, err)
+
+		has, err := checker.ShardMigrated(ctx, cid)
+		require.NoError(t, err)
+		require.True(t, has, "expected shard to be migrated in store table")
+	})
+
+	t.Run("exists in blob registry table", func(t *testing.T) {
+
+		cid := testutil.RandomCID()
+		space := testutil.RandomPrincipal().DID()
+		_, err := dynamoClient.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(blobRegistryTable),
+			Item: map[string]types.AttributeValue{
+				"digest": &types.AttributeValueMemberS{Value: cid.(cidlink.Link).Cid.Hash().B58String()},
+				"space":  &types.AttributeValueMemberS{Value: space.DID().String()},
+			},
+		})
+		require.NoError(t, err)
+
+		has, err := checker.ShardMigrated(ctx, cid)
+		require.NoError(t, err)
+		require.True(t, has, "expected shard to be migrated in store table")
+	})
+
+	t.Run("does not exist in either table", func(t *testing.T) {
+		cid := testutil.RandomCID()
+		has, err := checker.ShardMigrated(ctx, cid)
+		require.NoError(t, err)
+		require.False(t, has, "expected shard to not be migrated in either table")
+	})
+}
+
+func createStoreTable(t *testing.T, c *dynamodb.Client, tableName string) {
+	_, err := c.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("cid"),
+				KeySchema: []types.KeySchemaElement{
+					{
+						AttributeName: aws.String("link"),
+						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("space"),
+						KeyType:       types.KeyTypeRange,
+					},
+				},
+				Projection: &types.Projection{
+					ProjectionType: types.ProjectionTypeAll,
+				},
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("link"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("space"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("space"),
+				KeyType:       types.KeyTypeHash,
+			},
+			{
+				AttributeName: aws.String("link"),
+				KeyType:       types.KeyTypeRange,
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func createBlobRegistryTable(t *testing.T, c *dynamodb.Client, tableName string) {
+	_, err := c.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("digest"),
+				KeySchema: []types.KeySchemaElement{
+					{
+						AttributeName: aws.String("digest"),
+						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("space"),
+						KeyType:       types.KeyTypeRange,
+					},
+				},
+				Projection: &types.Projection{
+					ProjectionType: types.ProjectionTypeAll,
+				},
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("digest"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("space"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("space"),
+				KeyType:       types.KeyTypeHash,
+			},
+			{
+				AttributeName: aws.String("digest"),
+				KeyType:       types.KeyTypeRange,
+			},
+		},
+	})
+	require.NoError(t, err)
+}

--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -97,6 +97,7 @@ type Config struct {
 	LegacyBlobRegistryTableRegion     string
 	LegacyAllocationsTableName        string
 	LegacyAllocationsTableRegion      string
+	LegacyDotStorageBucketPrefixes    []string // legacy .storage buckets
 	LegacyDataBucketURL               string
 	BaseTraceSampleRatio              float64
 	SentryDSN                         string
@@ -252,6 +253,7 @@ func FromEnv(ctx context.Context) Config {
 		LegacyAllocationsTableName:        mustGetEnv("LEGACY_ALLOCATIONS_TABLE_NAME"),
 		LegacyAllocationsTableRegion:      mustGetEnv("LEGACY_ALLOCATIONS_TABLE_REGION"),
 		LegacyDataBucketURL:               mustGetEnv("LEGACY_DATA_BUCKET_URL"),
+		LegacyDotStorageBucketPrefixes:    strings.Split(mustGetEnv("LEGACY_DOT_STORAGE_BUCKET_PREFIXES"), ","),
 		BaseTraceSampleRatio:              mustGetFloat("BASE_TRACE_SAMPLE_RATIO"),
 		SentryDSN:                         os.Getenv("SENTRY_DSN"),
 		SentryEnvironment:                 os.Getenv("SENTRY_ENVIRONMENT"),
@@ -323,7 +325,7 @@ func Construct(cfg Config) (types.Service, error) {
 	// allow claims synthethized from the block index table to live longer after they are expired in the cache
 	// so that the service doesn't return cached but expired delegations
 	synthetizedClaimExp := time.Duration(cfg.ClaimsCacheExpirationSeconds)*time.Second + 1*time.Hour
-	blockIndexTableMapper, err := NewBlockIndexTableMapper(cfg.Signer, legacyBlockIndexStore, legacyMigratedShardChecker, cfg.LegacyDataBucketURL, synthetizedClaimExp)
+	blockIndexTableMapper, err := NewBlockIndexTableMapper(cfg.Signer, legacyBlockIndexStore, legacyMigratedShardChecker, cfg.LegacyDataBucketURL, synthetizedClaimExp, cfg.LegacyDotStorageBucketPrefixes)
 	if err != nil {
 		return nil, fmt.Errorf("creating block index table mapper: %w", err)
 	}

--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -321,6 +321,7 @@ func Construct(cfg Config) (types.Service, error) {
 		dynamodb.NewFromConfig(blobRegistryTableCfg),
 		cfg.LegacyStoreTableName,
 		cfg.LegacyBlobRegistryTableName,
+		legacyAllocationsStore,
 	)
 	// allow claims synthethized from the block index table to live longer after they are expired in the cache
 	// so that the service doesn't return cached but expired delegations


### PR DESCRIPTION
# Goals

implements blocking of retrievals by skipping old web3.storage cids that are not listed in the store table or the blob-registry table per #213 

# Implementation

- in block index table mapper
   - skip shards if they are dot storage shards and are not listed as migrated
- implement migrated shard checker
   - checks both store table and blob registry table to see if a shard is migrated
- update deploy configs

# For Discussion

Before we ship this, I really need to test round trip by deploying an indexer env connected to prod