### PR TITLE
feat: query result messages

### DIFF
--- a/pkg/service/contentclaims/simplefinder.go
+++ b/pkg/service/contentclaims/simplefinder.go
@@ -18,6 +18,21 @@ type simpleFinder struct {
 
 var _ Finder = (*simpleFinder)(nil)
 
+// ClaimFetchError is an error that occurred while attempting to fetch a claim
+// from the network. This is typically a non-fatal error for indexer queries so
+// this error type is public to allow detection via [errors.As].
+type ClaimFetchError struct {
+	err error
+}
+
+func (cfe ClaimFetchError) Error() string {
+	return fmt.Errorf("fetching claim: %w", cfe.err).Error()
+}
+
+func (cfe ClaimFetchError) Unwrap() error {
+	return cfe.err
+}
+
 // NewSimpleFinder creates a new [Finder] with the provided HTTP client.
 func NewSimpleFinder(httpClient *http.Client) Finder {
 	return &simpleFinder{
@@ -30,26 +45,26 @@ func (sf *simpleFinder) Find(ctx context.Context, id ipld.Link, fetchURL *url.UR
 	// attempt to fetch the claim from provided url
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, ClaimFetchError{fmt.Errorf("failed to create request: %w", err)}
 	}
 
 	resp, err := sf.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch claim: %w", err)
+		return nil, ClaimFetchError{fmt.Errorf("failed to fetch claim: %w", err)}
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading fetched claim body: %w", err)
+		return nil, ClaimFetchError{fmt.Errorf("reading fetched claim body: %w", err)}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("failure response fetching claim. URL: %s, status: %s, message: %s", fetchURL.String(), resp.Status, string(body))
+		return nil, ClaimFetchError{fmt.Errorf("failure response fetching claim. URL: %s, status: %s, message: %s", fetchURL.String(), resp.Status, string(body))}
 	}
 	dlg, err := delegation.Extract(body)
 	if err != nil {
-		return nil, fmt.Errorf("extracting delegation from archive: %w", err)
+		return nil, ClaimFetchError{fmt.Errorf("extracting delegation from archive: %w", err)}
 	}
 	if id.String() != dlg.Link().String() {
-		return nil, fmt.Errorf("received delegation: %s, does not match expected delegation: %s", dlg.Link(), id)
+		return nil, ClaimFetchError{fmt.Errorf("received delegation: %s, does not match expected delegation: %s", dlg.Link(), id)}
 	}
 	return dlg, nil
 }

--- a/pkg/service/queryresult/datamodel/queryresult.go
+++ b/pkg/service/queryresult/datamodel/queryresult.go
@@ -31,12 +31,20 @@ func QueryResultType() schema.Type {
 // QueryResultModel is the golang structure for encoding query results
 type QueryResultModel struct {
 	Result0_1 *QueryResultModel0_1
+	Result0_2 *QueryResultModel0_2
 }
 
 // QueryResultModel0_1 describes the found claims and indexes for a given query
 type QueryResultModel0_1 struct {
 	Claims  []ipld.Link
 	Indexes *IndexesModel
+}
+
+// QueryResultModel0_2 describes the found claims and indexes for a given query
+type QueryResultModel0_2 struct {
+	Claims   []ipld.Link
+	Indexes  *IndexesModel
+	Messages []string
 }
 
 // IndexesModel maps encoded context IDs to index links

--- a/pkg/service/queryresult/datamodel/queryresult.ipldsch
+++ b/pkg/service/queryresult/datamodel/queryresult.ipldsch
@@ -1,8 +1,15 @@
 type QueryResult union {
   | QueryResult0_1 "index/query/result@0.1"
+  | QueryResult0_2 "index/query/result@0.2"
 } representation keyed
 
 type QueryResult0_1 struct {
   claims optional [Link]
   indexes optional {String:Link}
+}
+
+type QueryResult0_2 struct {
+  claims optional [Link]
+  indexes optional {String:Link}
+  messages optional [String]
 }

--- a/pkg/service/queryresult/queryresult_test.go
+++ b/pkg/service/queryresult/queryresult_test.go
@@ -1,0 +1,53 @@
+package queryresult
+
+import (
+	"io"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multicodec"
+	multihash "github.com/multiformats/go-multihash/core"
+	"github.com/storacha/go-libstoracha/blobindex"
+	"github.com/storacha/go-libstoracha/bytemap"
+	"github.com/storacha/go-libstoracha/testutil"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/indexing-service/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerde(t *testing.T) {
+	claim := testutil.RandomLocationDelegation(t)
+	claims := map[cid.Cid]delegation.Delegation{
+		claim.Link().(cidlink.Link).Cid: claim,
+	}
+
+	_, index := testutil.RandomShardedDagIndexView(t, 138)
+	indexBytes, err := io.ReadAll(testutil.Must(index.Archive())(t))
+	require.NoError(t, err)
+	indexLink, err := cid.Prefix{
+		Version:  1,
+		Codec:    uint64(multicodec.Car),
+		MhType:   multihash.SHA2_256,
+		MhLength: -1,
+	}.Sum(indexBytes)
+	require.NoError(t, err)
+
+	contextID := types.ContextID{Hash: indexLink.Hash()}
+	indexes := bytemap.NewByteMap[types.EncodedContextID, blobindex.ShardedDagIndexView](-1)
+	indexes.Set(testutil.Must(contextID.ToEncoded())(t), index)
+
+	msgs := []string{"hello world"}
+
+	qr, err := Build(claims, indexes, WithMessage(msgs...))
+	require.NoError(t, err)
+
+	qr, err = Extract(Archive(qr))
+	require.NoError(t, err)
+
+	require.Len(t, qr.Claims(), 1)
+	require.Equal(t, qr.Claims()[0].String(), claim.Link().String())
+	require.Len(t, qr.Indexes(), 1)
+	require.Equal(t, qr.Indexes()[0].String(), indexLink.String())
+	require.Equal(t, qr.Messages(), msgs)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -153,6 +153,8 @@ type QueryResult interface {
 	// Indexes is a list of links to the CID hash of archived sharded dag indexes that can be found in this
 	// message
 	Indexes() []ipld.Link
+	// Messages may contain non-fatal issues that occurred during query execution.
+	Messages() []string
 }
 
 type Getter interface {


### PR DESCRIPTION
From convo in discord:

> The indexing service should always return a query result, even if an error is encountered.
>
> An error should be a field in the returned query result.
>
> It would allow the service to return what it found, even if it encountered errors in follow on jobs.
>
>It also prevents a bad storage node from eclipsing results for data stored on a good node.
>
> Contrived example: a node stores some data but then goes offline, but it was replicated to another node - the error for not being able to fetch a shard from the offline node does not prevent the query from completing...
>
> It aids debugging - you can get a partial result and an error that would allow you to determine how far the indexer got with the query.

This PR adds a "messages" property to the query result that allows warnings and other information to be returned in a query result. It also alters the service to return non-fatal errors in this field.