### PR TITLE
fix: allow publishing claims by POSTing to `/` too

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,6 +96,8 @@ func NewServer(indexer types.Service, opts ...Option) *http.ServeMux {
 	mux := http.NewServeMux()
 	maybeInstrumentAndAdd(mux, "GET /", GetRootHandler(c.id), c.enableTelemetry)
 	maybeInstrumentAndAdd(mux, "GET /claim/{claim}", GetClaimHandler(indexer), c.enableTelemetry)
+	// temporary fix: post claims handler accessible at POST / too
+	maybeInstrumentAndAdd(mux, "POST /", PostClaimsHandler(c.id, indexer, c.contentClaimsOptions...), c.enableTelemetry)
 	maybeInstrumentAndAdd(mux, "POST /claims", PostClaimsHandler(c.id, indexer, c.contentClaimsOptions...), c.enableTelemetry)
 	maybeInstrumentAndAdd(mux, "GET /claims", GetClaimsHandler(indexer), c.enableTelemetry)
 	maybeInstrumentAndAdd(mux, "GET /.well-known/did.json", GetDIDDocument(c.id), c.enableTelemetry)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.9.0"
+  "version": "v1.9.1"
 }


### PR DESCRIPTION
It looks like piri sends claims as `POST /` instead of `POST /claims`. Let's allow it while it gets fixed.