### PR TITLE
fix: migrated shard checker was getting mixed table names

### DIFF
--- a/pkg/aws/dynamomigratedshardchecker.go
+++ b/pkg/aws/dynamomigratedshardchecker.go
@@ -66,7 +66,7 @@ func (d *DynamoMigratedShardChecker) blobRegistryTableShardMigrated(ctx context.
 		Select:                    dynamotypes.SelectCount,
 	})
 	if err != nil {
-		return false, fmt.Errorf("querying store table: %w", err)
+		return false, fmt.Errorf("querying blob registry table: %w", err)
 	}
 	return o.Count > 0, nil
 }
@@ -85,12 +85,12 @@ func (d *DynamoMigratedShardChecker) ShardMigrated(ctx context.Context, shard ip
 	return d.allocationsStore.Has(ctx, shard.(cidlink.Link).Cid.Hash())
 }
 
-func NewDynamoMigratedShardChecker(storeTableClient dynamodb.QueryAPIClient, blobRegistryTableClient dynamodb.QueryAPIClient, blobRegistryTableName, storeTableName string, allocationsStore AllocationsStore) *DynamoMigratedShardChecker {
+func NewDynamoMigratedShardChecker(storeTableName string, storeTableClient dynamodb.QueryAPIClient, blobRegistryTableName string, blobRegistryTableClient dynamodb.QueryAPIClient, allocationsStore AllocationsStore) *DynamoMigratedShardChecker {
 	return &DynamoMigratedShardChecker{
-		storeTableClient:        storeTableClient,
-		blobRegistryTableClient: blobRegistryTableClient,
-		blobRegistryTableName:   blobRegistryTableName,
 		storeTableName:          storeTableName,
+		storeTableClient:        storeTableClient,
+		blobRegistryTableName:   blobRegistryTableName,
+		blobRegistryTableClient: blobRegistryTableClient,
 		allocationsStore:        allocationsStore,
 	}
 }

--- a/pkg/aws/dynamomigratedshardchecker_test.go
+++ b/pkg/aws/dynamomigratedshardchecker_test.go
@@ -32,7 +32,7 @@ func TestDynamoMigratedShardChecker(t *testing.T) {
 	createBlobRegistryTable(t, dynamoClient, blobRegistryTable)
 	createAllocationsTable(t, dynamoClient, allocationsTable)
 	allocationsStore := NewDynamoAllocationsTable(dynamoClient, allocationsTable)
-	checker := NewDynamoMigratedShardChecker(dynamoClient, dynamoClient, blobRegistryTable, storeTable, allocationsStore)
+	checker := NewDynamoMigratedShardChecker(storeTable, dynamoClient, blobRegistryTable, dynamoClient, allocationsStore)
 
 	t.Run("exists in store table", func(t *testing.T) {
 

--- a/pkg/aws/service.go
+++ b/pkg/aws/service.go
@@ -311,10 +311,10 @@ func Construct(cfg Config) (types.Service, error) {
 	blobRegistryTableCfg := cfg.Config.Copy()
 	blobRegistryTableCfg.Region = cfg.LegacyBlobRegistryTableRegion
 	legacyMigratedShardChecker := NewDynamoMigratedShardChecker(
-		dynamodb.NewFromConfig(storeTableCfg),
-		dynamodb.NewFromConfig(blobRegistryTableCfg),
 		cfg.LegacyStoreTableName,
+		dynamodb.NewFromConfig(storeTableCfg),
 		cfg.LegacyBlobRegistryTableName,
+		dynamodb.NewFromConfig(blobRegistryTableCfg),
 		legacyAllocationsStore,
 	)
 	// allow claims synthethized from the block index table to live longer after they are expired in the cache


### PR DESCRIPTION
We were interchanging the table names when creating the migrated shard checker, which caused queries to fail.