### PR TITLE
fix: legacy dynamodb policy should allow access to the indexes

### DIFF
--- a/deploy/app/legacyclaims.tf
+++ b/deploy/app/legacyclaims.tf
@@ -78,8 +78,8 @@ data "aws_iam_policy_document" "task_legacy_dynamodb_query_document" {
       data.aws_dynamodb_table.legacy_block_index_table.arn,
       data.aws_dynamodb_table.legacy_allocations_table.arn,
       "${data.aws_dynamodb_table.legacy_allocations_table.arn}/index/*",
-      data.aws_dynamodb_table.legacy_store_table.arn,
-      data.aws_dynamodb_table.legacy_blob_registry_table.arn,
+      "${data.aws_dynamodb_table.legacy_store_table.arn}/index/cid",
+      "${data.aws_dynamodb_table.legacy_blob_registry_table.arn}/index/digest",
     ]
   }
 }


### PR DESCRIPTION
The policy was allowing queries to the table, but the code actually queries the indexes (and only the indexes).

I confirmed this works by editing the policy manually for staging in the console.