### PR TITLE
fix: make deployment depend on test success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,20 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  # First run the tests for pushes to main
+  run-tests:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/go-test.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  
+  run-checks:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/go-check.yml
+
   # apply staging on pushes to main, plan otherwise
   staging:
+    needs: [run-tests, run-checks]
     uses: ./.github/workflows/terraform.yml
     with:
       env: staging
@@ -40,6 +52,7 @@ jobs:
       sentry-dsn: ${{ secrets.STAGING_SENTRY_DSN }}
 
   warm-staging:
+    needs: [run-tests, run-checks]
     uses: ./.github/workflows/terraform.yml
     with:
       env: warm-staging
@@ -61,6 +74,7 @@ jobs:
 
   # apply prod on successful release, plan otherwise
   production:
+    needs: [run-tests, run-checks]
     uses: ./.github/workflows/terraform.yml
     with:
       env: production


### PR DESCRIPTION
## Fix: Make Deployment Depend on Test Success

### 🐛 Problem

Currently, the deployment workflow and test workflows run in parallel when code is pushed to the `main` branch. This creates a dangerous race condition where:

- Deployment could complete before tests finish running
- Buggy code could potentially be deployed even if tests fail
- There's no explicit guarantee that tests pass before deployment begins

While PR merge protection should prevent this, the protection can be bypassed, and making the dependency explicit improves pipeline safety and reliability.

### 🔧 Solution

This PR modifies the `.github/workflows/deploy.yml` workflow to:

1. **Add explicit test jobs** that call the existing `go-test.yml` and `go-check.yml` workflows
2. **Use `needs` dependencies** to ensure all deployment jobs wait for tests to complete successfully
3. **Apply conditional logic** so test jobs only run on pushes to `main` (not PRs or manual dispatches)

### 📝 Changes Made

### Modified Files
- `.github/workflows/deploy.yml` - Added test dependencies to deployment jobs

### Key Changes
```yaml
jobs:
  # First run the tests for pushes to main
  run-tests:
    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
    uses: ./.github/workflows/go-test.yml
    secrets:
      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
  
  run-checks:
    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
    uses: ./.github/workflows/go-check.yml

  # All deployment jobs now depend on tests
  staging:
    needs: [run-tests, run-checks]
    # ... rest of config

  warm-staging:
    needs: [run-tests, run-checks]
    # ... rest of config

  production:
    needs: [run-tests, run-checks]
    # ... rest of config
```

### ✅ Benefits

- **🛡️ Safety**: Guarantees tests complete successfully before any deployment
- **⚡ Fast Failure**: Deployment stops immediately if tests fail, saving resources
- **🔍 Visibility**: GitHub UI clearly shows the dependency chain
- **💰 Cost Efficiency**: Deployment resources aren't consumed when tests fail
- **🎯 Explicit Dependencies**: No more relying on implicit assumptions about test timing

This PR resolves the issue described in #106 