### PR TITLE
feat: support query for equals or location claims

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -93,7 +93,7 @@ var targetClaims = map[types.QueryType][]multicodec.Code{
 	types.QueryTypeStandardCompressed: {metadata.EqualsClaimID, metadata.IndexClaimID, metadata.LocationCommitmentID},
 	types.QueryTypeLocation:           {metadata.LocationCommitmentID},
 	types.QueryTypeIndexOrLocation:    {metadata.IndexClaimID, metadata.LocationCommitmentID},
-	types.QueryTypeEquals:             {metadata.EqualsClaimID},
+	types.QueryTypeEqualsOrLocation:   {metadata.EqualsClaimID, metadata.LocationCommitmentID},
 }
 
 type queryResult struct {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -93,6 +93,7 @@ var targetClaims = map[types.QueryType][]multicodec.Code{
 	types.QueryTypeStandardCompressed: {metadata.EqualsClaimID, metadata.IndexClaimID, metadata.LocationCommitmentID},
 	types.QueryTypeLocation:           {metadata.LocationCommitmentID},
 	types.QueryTypeIndexOrLocation:    {metadata.IndexClaimID, metadata.LocationCommitmentID},
+	types.QueryTypeEquals:             {metadata.EqualsClaimID},
 }
 
 type queryResult struct {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -308,15 +308,15 @@ func TestQuery(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("equals query: equals only", func(t *testing.T) {
+		t.Run("equals_or_location: equals and location", func(t *testing.T) {
 			query := types.Query{
-				Type:   types.QueryTypeEquals,
+				Type:   types.QueryTypeEqualsOrLocation,
 				Hashes: []mh.Multihash{contentHash},
 			}
 
 			expectedQueryKey := providerindex.QueryKey{
 				Hash:         contentHash,
-				TargetClaims: []multicodec.Code{metadata.EqualsClaimID},
+				TargetClaims: []multicodec.Code{metadata.EqualsClaimID, metadata.LocationCommitmentID},
 			}
 
 			mockProviderIndex.EXPECT().Find(extmocks.AnyContext, expectedQueryKey).Return([]model.ProviderResult{}, nil)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -307,6 +307,23 @@ func TestQuery(t *testing.T) {
 			_, err := service.Query(t.Context(), query)
 			require.NoError(t, err)
 		})
+
+		t.Run("equals query: equals only", func(t *testing.T) {
+			query := types.Query{
+				Type:   types.QueryTypeEquals,
+				Hashes: []mh.Multihash{contentHash},
+			}
+
+			expectedQueryKey := providerindex.QueryKey{
+				Hash:         contentHash,
+				TargetClaims: []multicodec.Code{metadata.EqualsClaimID},
+			}
+
+			mockProviderIndex.EXPECT().Find(extmocks.AnyContext, expectedQueryKey).Return([]model.ProviderResult{}, nil)
+
+			_, err := service.Query(t.Context(), query)
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("returns error when ProviderIndex service errors", func(t *testing.T) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -114,6 +114,7 @@ const (
 	QueryTypeLocation
 	QueryTypeIndexOrLocation
 	QueryTypeStandardCompressed
+	QueryTypeEquals
 )
 
 func (qt QueryType) String() string {
@@ -126,6 +127,8 @@ func (qt QueryType) String() string {
 		return "index_or_location"
 	case QueryTypeStandardCompressed:
 		return "standard_compressed"
+	case QueryTypeEquals:
+		return "equals"
 	default:
 		return "invalid"
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -114,7 +114,7 @@ const (
 	QueryTypeLocation
 	QueryTypeIndexOrLocation
 	QueryTypeStandardCompressed
-	QueryTypeEquals
+	QueryTypeEqualsOrLocation
 )
 
 func (qt QueryType) String() string {
@@ -127,8 +127,8 @@ func (qt QueryType) String() string {
 		return "index_or_location"
 	case QueryTypeStandardCompressed:
 		return "standard_compressed"
-	case QueryTypeEquals:
-		return "equals"
+	case QueryTypeEqualsOrLocation:
+		return "equals_or_location"
 	default:
 		return "invalid"
 	}


### PR DESCRIPTION
Will eventually allow Spade to authorize retrievals from Forge. Spade has a list of pieces that make up an aggregate and needs to map from piece CID to blob CID + location URL in order to authorize retrieval. This allows more efficient bulk equivalency mapping of multiple CIDs by not having to consider indexes.

refs https://github.com/storacha/spade-agent/issues/7